### PR TITLE
[오류 수정] 배포 자동화 파일 수정

### DIFF
--- a/.github/workflows/ec2_cd.yml
+++ b/.github/workflows/ec2_cd.yml
@@ -16,7 +16,7 @@ jobs:
                   EC2_USER_NAME: ${{ secrets.EC2_USER_NAME }}
               run: |
                   echo "${EC2_PRIVATE_KEY}" > ec2_private_key
-                  chmod 777 ec2_private_key
+                  chmod 600 ec2_private_key
                   ssh -o StrictHostKeyChecking=no -i ec2_private_key ${EC2_USER_NAME}@${EC2_HOST} '
                     cd /project-management &&
                     git checkout main &&


### PR DESCRIPTION
## 반영 브랜치
hotfix/cd/#3 → develop


## 변경 사항
GitHub Actions를 활용한 배포 자동화 시도 중 발생한 에러를 수정하기 위한 PR입니다. 에러 내용은 다음과 같습니다.

```
Run echo "${EC2_PRIVATE_KEY}" > ec2_private_key
Warning: Permanently added '***' (ED255[19](https://github.com/allen9535/project-management-system/actions/runs/6885382166/job/18729434049#step:2:20)) to the list of known hosts.
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0777 for 'ec2_private_key' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
Load key "ec2_private_key": bad permissions
***@***: Permission denied (publickey).
Error: Process completed with exit code 255.
```

혹시 몰라서 권한을 777로 제공하려 했는데, 너무 과한 권한이라는 에러 메시지를 받게 되었습니다. 이에 권한을 600으로 수정합니다.