### PR TITLE
[기능 생성] 컬럼 목록 확인 기능 생성

### DIFF
--- a/boards/permissions.py
+++ b/boards/permissions.py
@@ -27,3 +27,13 @@ class CanCreateColumn(BasePermission):
         # 해당 팀의 팀장만 컬럼 생성 가능
         # 해당 팀의 팀장이다 → True / 그 외 → False
         return (user.groups.filter(name='leader').exists()) and (team.leader == user)
+
+
+# 보드 목록 확인은 팀장과 팀원만 가능함
+# 관련 권한 정의
+class CanReadBoardList(BasePermission):
+    def has_permission(self, request, view):
+        user = request.user
+
+        # 팀장 이외의 그룹은 모두 팀 그룹이므로
+        return user.groups.exclude(name='leader').exists()

--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -1,9 +1,47 @@
 from rest_framework import serializers
 
-from .models import Column
+from .models import Board, Column
 
 
 class ColumnSerializer(serializers.ModelSerializer):
     class Meta:
         model = Column
         fields = '__all__'
+
+
+class BoardSerializer(serializers.ModelSerializer):
+    # 보드를 그대로 직렬화하면 팀은 팀 id만 나옴
+    # 따라서 별도의 메서드를 통해 어떤 값을 반환할지 결정함
+    team = serializers.SerializerMethodField()
+    # 보드에 컬럼과 관련된 값은 없지만, 컬럼은 보드를 외래키로 가지고 있음
+    # 이를 활용해 원하는 값을 반환함
+    column = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Board
+        fields = ['team', 'column']
+
+    # team 필드에 어떤 값을 반환할지 결정하는 메서드
+    def get_team(self, obj):
+        # 시리얼라이저에 들어온 보드 객체에서 팀명을 가져옴
+        return obj.team.name
+
+    # column 필드에 어떤 값을 반환할지 결정하는 메서드
+    def get_column(self, obj):
+        # 시리얼라이저에 들어온 보드 객체에 소속된 모든 컬럼을 오름차순으로 정렬
+        columns = Column.objects.filter(board=obj).order_by('sequence')
+
+        # 해당 데이터에서 필요한 내용만 딕셔너리 형태로 반환
+        # {
+        #    'team': '팀명',
+        #    'column': {
+        #       '컬럼명': 순서,
+        #       '컬럼명': 순서,
+        #        ...
+        #     }
+        # }
+        column_data = {}
+        for column in columns:
+            column_data[column.title] = column.sequence
+
+        return column_data

--- a/boards/tests.py
+++ b/boards/tests.py
@@ -182,3 +182,98 @@ class ColumnCreateTestCase(APITestCase):
             print(response.data)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+# 보드 목록 테스트
+class BoardListTestCase(APITestCase):
+    fixtures = ['db.json']
+
+    def setUp(self):
+        # APIClient 객체 생성
+        self.client = APIClient()
+
+        # /api/v1/boards/board/list/
+        self.url = reverse('board_list')
+
+    # 팀장이 보드를 확인하는 케이스
+    def test_leader_reads(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        response = self.client.get(self.url)
+
+        if response.status_code != 200:
+            print(response.data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # 팀원이 보드를 확인하는 케이스
+    def test_teammate_reads(self):
+        # 기존 DB의 사용자 중 팀원 사용자로 로그인 시도
+        login_data = {
+            'username': 'normaluser1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        response = self.client.get(self.url)
+
+        if response.status_code != 200:
+            print(response.data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # 팀에 소속되지 않은 사용자가 보드를 확인하는 케이스
+    def test_outsider_reads(self):
+        # 기존 DB의 사용자 중 팀에 소속되지 않은 사용자로 로그인 시도
+        login_data = {
+            'username': 'normaluser4',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        response = self.client.get(self.url)
+
+        # 권한 문제이기 때문에 상태코드는 403이 나옴
+        if response.status_code != 403:
+            print(response.data)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # 인증되지 않은 사용자가 보드를 확인하는 케이스
+    def test_outsider_reads(self):
+        response = self.client.get(self.url)
+
+        # 인증 문제이기 때문에 상태코드는 401이 나옴
+        if response.status_code != 401:
+            print(response.data)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from .views import ColumnCreateView
+from .views import BoardListView, ColumnCreateView
 
 
 urlpatterns = [
+    path('board/list/', BoardListView.as_view(), name='board_list'),
     path('column/create/', ColumnCreateView.as_view(), name='column_create'),
 ]

--- a/boards/views.py
+++ b/boards/views.py
@@ -3,13 +3,16 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 
-from django.contrib.auth.models import Group
 from django.core.exceptions import ObjectDoesNotExist
 
+from drf_yasg.utils import swagger_auto_schema
+
 from teams.models import Team
-from .permissions import CanCreateColumn
+from .permissions import CanCreateColumn, CanReadBoardList
 from .models import Board, Column
-from .serializers import ColumnSerializer
+from .serializers import ColumnSerializer, BoardSerializer
+
+from swagger import COLUMN_CREATE_PARAMETER
 
 
 # /api/v1/boards/column/create/
@@ -19,6 +22,18 @@ class ColumnCreateView(APIView):
     # 컬럼 생성 가능한 사용자: 요청으로 넘어온 팀의 팀장
     permission_classes = [IsAuthenticated, CanCreateColumn]
 
+    @swagger_auto_schema(
+        operation_id='컬럼 생성',
+        operation_description='팀이 소유한 보드에 컬럼을 새로 생성합니다.',
+        tags=['컬럼', '생성'],
+        request_body=COLUMN_CREATE_PARAMETER,
+        responses={
+            201: '성공적으로 컬럼을 생성했습니다.',
+            400: '입력값 오류. 컬럼 생성에 실패했습니다. 잘못된 값이 입력되었습니다.',
+            401: '인증 오류. 인증되지 않은 사용자입니다.',
+            403: '권한 오류. 팀장이 자기 보드에만 컬럼을 생성할 수 있습니다.'
+        }
+    )
     def post(self, request):
         user = request.user
 
@@ -65,3 +80,35 @@ class ColumnCreateView(APIView):
 
         # 값이 유효하지 않은 경우
         return Response({'data': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+
+# /api/v1/boards/board/list/
+class BoardListView(APIView):
+    # 권한 설정
+    # 인증된 사용자, 보드 내용 확인 가능한 사용자에게만 권한 부여
+    # 보드 내용 확인 가능한 사용자: 요청으로 넘어온 팀의 팀장 또는 팀원
+    permission_classes = [IsAuthenticated, CanReadBoardList]
+
+    def get(self, request):
+        user = request.user
+        # 구조상 사용자가 소속된 그룹들 중 팀장 그룹을 제외하면 팀 그룹 하나밖에 없음
+        # 그 팀 그룹의 이름을 통해 팀 객체 가져옴
+        user_team = Team.objects.get(
+            name=user.groups.exclude(name='leader').first().name
+        )
+
+        # 가져온 팀 객체로 보드 가져옴
+        board = Board.objects.get(team=user_team)
+        # 시리얼라이저로 직렬화 한 후 데이터 반환
+        # 컬럼명과 순서를 딕셔너리 형태로 직렬화함
+        # {
+        #    'team': '팀명',
+        #    'column': {
+        #       '컬럼명': 순서,
+        #       '컬럼명': 순서,
+        #        ...
+        #     }
+        # }
+        serializer = BoardSerializer(board)
+
+        return Response({'data': serializer.data}, status=status.HTTP_200_OK)

--- a/db.json
+++ b/db.json
@@ -1,1 +1,1136 @@
-[{"model": "auth.permission", "pk": 1, "fields": {"name": "Can add log entry", "content_type": 1, "codename": "add_logentry"}}, {"model": "auth.permission", "pk": 2, "fields": {"name": "Can change log entry", "content_type": 1, "codename": "change_logentry"}}, {"model": "auth.permission", "pk": 3, "fields": {"name": "Can delete log entry", "content_type": 1, "codename": "delete_logentry"}}, {"model": "auth.permission", "pk": 4, "fields": {"name": "Can view log entry", "content_type": 1, "codename": "view_logentry"}}, {"model": "auth.permission", "pk": 5, "fields": {"name": "Can add permission", "content_type": 2, "codename": "add_permission"}}, {"model": "auth.permission", "pk": 6, "fields": {"name": "Can change permission", "content_type": 2, "codename": "change_permission"}}, {"model": "auth.permission", "pk": 7, "fields": {"name": "Can delete permission", "content_type": 2, "codename": "delete_permission"}}, {"model": "auth.permission", "pk": 8, "fields": {"name": "Can view permission", "content_type": 2, "codename": "view_permission"}}, {"model": "auth.permission", "pk": 9, "fields": {"name": "Can add group", "content_type": 3, "codename": "add_group"}}, {"model": "auth.permission", "pk": 10, "fields": {"name": "Can change group", "content_type": 3, "codename": "change_group"}}, {"model": "auth.permission", "pk": 11, "fields": {"name": "Can delete group", "content_type": 3, "codename": "delete_group"}}, {"model": "auth.permission", "pk": 12, "fields": {"name": "Can view group", "content_type": 3, "codename": "view_group"}}, {"model": "auth.permission", "pk": 13, "fields": {"name": "Can add content type", "content_type": 4, "codename": "add_contenttype"}}, {"model": "auth.permission", "pk": 14, "fields": {"name": "Can change content type", "content_type": 4, "codename": "change_contenttype"}}, {"model": "auth.permission", "pk": 15, "fields": {"name": "Can delete content type", "content_type": 4, "codename": "delete_contenttype"}}, {"model": "auth.permission", "pk": 16, "fields": {"name": "Can view content type", "content_type": 4, "codename": "view_contenttype"}}, {"model": "auth.permission", "pk": 17, "fields": {"name": "Can add session", "content_type": 5, "codename": "add_session"}}, {"model": "auth.permission", "pk": 18, "fields": {"name": "Can change session", "content_type": 5, "codename": "change_session"}}, {"model": "auth.permission", "pk": 19, "fields": {"name": "Can delete session", "content_type": 5, "codename": "delete_session"}}, {"model": "auth.permission", "pk": 20, "fields": {"name": "Can view session", "content_type": 5, "codename": "view_session"}}, {"model": "auth.permission", "pk": 21, "fields": {"name": "Can add blacklisted token", "content_type": 6, "codename": "add_blacklistedtoken"}}, {"model": "auth.permission", "pk": 22, "fields": {"name": "Can change blacklisted token", "content_type": 6, "codename": "change_blacklistedtoken"}}, {"model": "auth.permission", "pk": 23, "fields": {"name": "Can delete blacklisted token", "content_type": 6, "codename": "delete_blacklistedtoken"}}, {"model": "auth.permission", "pk": 24, "fields": {"name": "Can view blacklisted token", "content_type": 6, "codename": "view_blacklistedtoken"}}, {"model": "auth.permission", "pk": 25, "fields": {"name": "Can add outstanding token", "content_type": 7, "codename": "add_outstandingtoken"}}, {"model": "auth.permission", "pk": 26, "fields": {"name": "Can change outstanding token", "content_type": 7, "codename": "change_outstandingtoken"}}, {"model": "auth.permission", "pk": 27, "fields": {"name": "Can delete outstanding token", "content_type": 7, "codename": "delete_outstandingtoken"}}, {"model": "auth.permission", "pk": 28, "fields": {"name": "Can view outstanding token", "content_type": 7, "codename": "view_outstandingtoken"}}, {"model": "auth.permission", "pk": 29, "fields": {"name": "Can add user", "content_type": 8, "codename": "add_user"}}, {"model": "auth.permission", "pk": 30, "fields": {"name": "Can change user", "content_type": 8, "codename": "change_user"}}, {"model": "auth.permission", "pk": 31, "fields": {"name": "Can delete user", "content_type": 8, "codename": "delete_user"}}, {"model": "auth.permission", "pk": 32, "fields": {"name": "Can view user", "content_type": 8, "codename": "view_user"}}, {"model": "auth.permission", "pk": 33, "fields": {"name": "Can add team", "content_type": 9, "codename": "add_team"}}, {"model": "auth.permission", "pk": 34, "fields": {"name": "Can change team", "content_type": 9, "codename": "change_team"}}, {"model": "auth.permission", "pk": 35, "fields": {"name": "Can delete team", "content_type": 9, "codename": "delete_team"}}, {"model": "auth.permission", "pk": 36, "fields": {"name": "Can view team", "content_type": 9, "codename": "view_team"}}, {"model": "auth.permission", "pk": 37, "fields": {"name": "Can add team member", "content_type": 10, "codename": "add_teammember"}}, {"model": "auth.permission", "pk": 38, "fields": {"name": "Can change team member", "content_type": 10, "codename": "change_teammember"}}, {"model": "auth.permission", "pk": 39, "fields": {"name": "Can delete team member", "content_type": 10, "codename": "delete_teammember"}}, {"model": "auth.permission", "pk": 40, "fields": {"name": "Can view team member", "content_type": 10, "codename": "view_teammember"}}, {"model": "auth.permission", "pk": 41, "fields": {"name": "Can add board", "content_type": 11, "codename": "add_board"}}, {"model": "auth.permission", "pk": 42, "fields": {"name": "Can change board", "content_type": 11, "codename": "change_board"}}, {"model": "auth.permission", "pk": 43, "fields": {"name": "Can delete board", "content_type": 11, "codename": "delete_board"}}, {"model": "auth.permission", "pk": 44, "fields": {"name": "Can view board", "content_type": 11, "codename": "view_board"}}, {"model": "auth.permission", "pk": 45, "fields": {"name": "Can add column", "content_type": 12, "codename": "add_column"}}, {"model": "auth.permission", "pk": 46, "fields": {"name": "Can change column", "content_type": 12, "codename": "change_column"}}, {"model": "auth.permission", "pk": 47, "fields": {"name": "Can delete column", "content_type": 12, "codename": "delete_column"}}, {"model": "auth.permission", "pk": 48, "fields": {"name": "Can view column", "content_type": 12, "codename": "view_column"}}, {"model": "auth.group", "pk": 1, "fields": {"name": "leader", "permissions": []}}, {"model": "auth.group", "pk": 2, "fields": {"name": "첫번째팀", "permissions": []}}, {"model": "auth.group", "pk": 3, "fields": {"name": "두번째팀", "permissions": []}}, {"model": "auth.group", "pk": 4, "fields": {"name": "세번째팀", "permissions": []}}, {"model": "auth.group", "pk": 5, "fields": {"name": "테스트팀", "permissions": []}}, {"model": "contenttypes.contenttype", "pk": 1, "fields": {"app_label": "admin", "model": "logentry"}}, {"model": "contenttypes.contenttype", "pk": 2, "fields": {"app_label": "auth", "model": "permission"}}, {"model": "contenttypes.contenttype", "pk": 3, "fields": {"app_label": "auth", "model": "group"}}, {"model": "contenttypes.contenttype", "pk": 4, "fields": {"app_label": "contenttypes", "model": "contenttype"}}, {"model": "contenttypes.contenttype", "pk": 5, "fields": {"app_label": "sessions", "model": "session"}}, {"model": "contenttypes.contenttype", "pk": 6, "fields": {"app_label": "token_blacklist", "model": "blacklistedtoken"}}, {"model": "contenttypes.contenttype", "pk": 7, "fields": {"app_label": "token_blacklist", "model": "outstandingtoken"}}, {"model": "contenttypes.contenttype", "pk": 8, "fields": {"app_label": "users", "model": "user"}}, {"model": "contenttypes.contenttype", "pk": 9, "fields": {"app_label": "teams", "model": "team"}}, {"model": "contenttypes.contenttype", "pk": 10, "fields": {"app_label": "teams", "model": "teammember"}}, {"model": "contenttypes.contenttype", "pk": 11, "fields": {"app_label": "boards", "model": "board"}}, {"model": "contenttypes.contenttype", "pk": 12, "fields": {"app_label": "boards", "model": "column"}}, {"model": "token_blacklist.outstandingtoken", "pk": 1, "fields": {"user": 1, "jti": "e279826a035f426080d81a0a397966b2", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQyNjcwMiwiaWF0IjoxNzAwMjE3MTAyLCJqdGkiOiJlMjc5ODI2YTAzNWY0MjYwODBkODFhMGEzOTc5NjZiMiIsInVzZXJfaWQiOjF9.vu8DqOFOiehgU-pQwmnwekRvfgzNuyHmUA6as_2z8lo", "created_at": "2023-11-17T10:31:42.513Z", "expires_at": "2023-12-01T10:31:42Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 2, "fields": {"user": 2, "jti": "b721e13969c847ccb2b68996361ad95d", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQyNjc4MiwiaWF0IjoxNzAwMjE3MTgyLCJqdGkiOiJiNzIxZTEzOTY5Yzg0N2NjYjJiNjg5OTYzNjFhZDk1ZCIsInVzZXJfaWQiOjJ9.B-tm6u9OyEw0wZXQrLMByq9sT6c0wYZnjZGrRM-OoGE", "created_at": "2023-11-17T10:33:02.117Z", "expires_at": "2023-12-01T10:33:02Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 3, "fields": {"user": 3, "jti": "6dbafb103b694389bcd96d21696e4875", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQyNjgwOCwiaWF0IjoxNzAwMjE3MjA4LCJqdGkiOiI2ZGJhZmIxMDNiNjk0Mzg5YmNkOTZkMjE2OTZlNDg3NSIsInVzZXJfaWQiOjN9.MZyzkIkVK1QK3tBeV41PUXiRGv_FcZW7qSKO9z0sDF0", "created_at": "2023-11-17T10:33:28.232Z", "expires_at": "2023-12-01T10:33:28Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 4, "fields": {"user": 1, "jti": "c59e08534d4d4a938badb053f52591f2", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQyNjgzNywiaWF0IjoxNzAwMjE3MjM3LCJqdGkiOiJjNTllMDg1MzRkNGQ0YTkzOGJhZGIwNTNmNTI1OTFmMiIsInVzZXJfaWQiOjF9.3nwXNU-xL9khXtCkk3b74ABX84hiC4Q2rVII0QeXLuA", "created_at": "2023-11-17T10:33:57.932Z", "expires_at": "2023-12-01T10:33:57Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 5, "fields": {"user": 2, "jti": "6b2d1589ade14486bdf84e34d4eaa3f5", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQyNjg3OSwiaWF0IjoxNzAwMjE3Mjc5LCJqdGkiOiI2YjJkMTU4OWFkZTE0NDg2YmRmODRlMzRkNGVhYTNmNSIsInVzZXJfaWQiOjJ9.cbiQTyfz4g75RF7pk0y1vHSjtsymxTZPlpu_0m2J7U4", "created_at": "2023-11-17T10:34:39.809Z", "expires_at": "2023-12-01T10:34:39Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 6, "fields": {"user": 3, "jti": "2eb64748b6a24b048db164fa2257eeea", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQyNjkwNywiaWF0IjoxNzAwMjE3MzA3LCJqdGkiOiIyZWI2NDc0OGI2YTI0YjA0OGRiMTY0ZmEyMjU3ZWVlYSIsInVzZXJfaWQiOjN9.h4ohB7wbPVz_KD0gZSIe28tXOsYk9-ETcYj7_0Ah1I0", "created_at": "2023-11-17T10:35:07.774Z", "expires_at": "2023-12-01T10:35:07Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 7, "fields": {"user": 1, "jti": "7d5e6fd639224718963592823761f073", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQyOTE3OCwiaWF0IjoxNzAwMjE5NTc4LCJqdGkiOiI3ZDVlNmZkNjM5MjI0NzE4OTYzNTkyODIzNzYxZjA3MyIsInVzZXJfaWQiOjF9.Dk_WSzn6905y8BLKpUNqlxfDhTkUv9c-xYpp509fAFE", "created_at": "2023-11-17T11:12:58.612Z", "expires_at": "2023-12-01T11:12:58Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 8, "fields": {"user": 8, "jti": "3698fb1586e74413a1305d35fae8d824", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQyOTkyMiwiaWF0IjoxNzAwMjIwMzIyLCJqdGkiOiIzNjk4ZmIxNTg2ZTc0NDEzYTEzMDVkMzVmYWU4ZDgyNCIsInVzZXJfaWQiOjh9.Xcd2slzI3z8Oz6zLpQvAtYU59OTm_7suH-p23_7rhJ4", "created_at": "2023-11-17T11:25:22.317Z", "expires_at": "2023-12-01T11:25:22Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 9, "fields": {"user": 9, "jti": "e07f89833f6a4b97895a272a68e661ad", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQzMDMxMiwiaWF0IjoxNzAwMjIwNzEyLCJqdGkiOiJlMDdmODk4MzNmNmE0Yjk3ODk1YTI3MmE2OGU2NjFhZCIsInVzZXJfaWQiOjl9._qzhiqtKKvM-ek5HL7pBWv1cV_MP0hSNfqcx-OZbSAs", "created_at": "2023-11-17T11:31:52.677Z", "expires_at": "2023-12-01T11:31:52Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 10, "fields": {"user": 1, "jti": "6d36803dcc824a84ac02e8313ec0cd6b", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQzMDMzOCwiaWF0IjoxNzAwMjIwNzM4LCJqdGkiOiI2ZDM2ODAzZGNjODI0YTg0YWMwMmU4MzEzZWMwY2Q2YiIsInVzZXJfaWQiOjF9.Ovte12MCK1sJAXsHqilXnr7hL705zNbGSJxFSrIGB0Q", "created_at": "2023-11-17T11:32:18.795Z", "expires_at": "2023-12-01T11:32:18Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 11, "fields": {"user": 9, "jti": "381fd9b516324f2f9c90d3797145ded6", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQzMDM3OCwiaWF0IjoxNzAwMjIwNzc4LCJqdGkiOiIzODFmZDliNTE2MzI0ZjJmOWM5MGQzNzk3MTQ1ZGVkNiIsInVzZXJfaWQiOjl9._qzFcY11Ue8TYOU0ZJTwOfETkIjjmSSCDLtDEd4TiTI", "created_at": "2023-11-17T11:32:58.892Z", "expires_at": "2023-12-01T11:32:58Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 12, "fields": {"user": 2, "jti": "6264d253306045fe924515ff0fccc9ad", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQzMDQwOCwiaWF0IjoxNzAwMjIwODA4LCJqdGkiOiI2MjY0ZDI1MzMwNjA0NWZlOTI0NTE1ZmYwZmNjYzlhZCIsInVzZXJfaWQiOjJ9.TPvgP9udyjfqOePyYlelRCT-jng1EAfDTKUosSpMomo", "created_at": "2023-11-17T11:33:28.519Z", "expires_at": "2023-12-01T11:33:28Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 13, "fields": {"user": 1, "jti": "49e561b8fd1e439a801caec2eaa259a0", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTQ5MDc5MiwiaWF0IjoxNzAwMjgxMTkyLCJqdGkiOiI0OWU1NjFiOGZkMWU0MzlhODAxY2FlYzJlYWEyNTlhMCIsInVzZXJfaWQiOjF9.iUd25I0E1Qh0opiGjvo7zrbFSA5alH-XPvacnDuYEC4", "created_at": "2023-11-18T04:19:52.855Z", "expires_at": "2023-12-02T04:19:52Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 14, "fields": {"user": 1, "jti": "207ad1706c7d4d08aa76e7b3bafad031", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUwMzUxMSwiaWF0IjoxNzAwMjkzOTExLCJqdGkiOiIyMDdhZDE3MDZjN2Q0ZDA4YWE3NmU3YjNiYWZhZDAzMSIsInVzZXJfaWQiOjF9.ct6c3HOQKPptdFhH9_Q7WRM0iqKcX9FZitn4HvbfB0c", "created_at": "2023-11-18T07:51:51.792Z", "expires_at": "2023-12-02T07:51:51Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 15, "fields": {"user": 4, "jti": "d1aee38143944b98b6c04c066ccd25cb", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUwNDkyMiwiaWF0IjoxNzAwMjk1MzIyLCJqdGkiOiJkMWFlZTM4MTQzOTQ0Yjk4YjZjMDRjMDY2Y2NkMjVjYiIsInVzZXJfaWQiOjR9.sbvLLbCFoF6AIWg1ffLqqwNO_3Q14Lq27W4kH6ROtxY", "created_at": "2023-11-18T08:15:22.761Z", "expires_at": "2023-12-02T08:15:22Z"}}, {"model": "token_blacklist.outstandingtoken", "pk": 16, "fields": {"user": 1, "jti": "9006540826f54373878b1ae3fd00845b", "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUwNTI4MCwiaWF0IjoxNzAwMjk1NjgwLCJqdGkiOiI5MDA2NTQwODI2ZjU0MzczODc4YjFhZTNmZDAwODQ1YiIsInVzZXJfaWQiOjF9.JWf4ArBkTBhjMp_IfrPNQGWz0QCc0g_mTeiHWxywkxA", "created_at": "2023-11-18T08:21:20.098Z", "expires_at": "2023-12-02T08:21:20Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 1, "fields": {"token": 1, "blacklisted_at": "2023-11-17T10:32:51.801Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 2, "fields": {"token": 2, "blacklisted_at": "2023-11-17T10:33:23.053Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 3, "fields": {"token": 3, "blacklisted_at": "2023-11-17T10:33:45.869Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 4, "fields": {"token": 4, "blacklisted_at": "2023-11-17T10:34:36.158Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 5, "fields": {"token": 5, "blacklisted_at": "2023-11-17T10:35:02.587Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 6, "fields": {"token": 6, "blacklisted_at": "2023-11-17T10:35:29.042Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 7, "fields": {"token": 9, "blacklisted_at": "2023-11-17T11:32:04.204Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 8, "fields": {"token": 10, "blacklisted_at": "2023-11-17T11:32:48.681Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 9, "fields": {"token": 11, "blacklisted_at": "2023-11-17T11:33:21.338Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 10, "fields": {"token": 14, "blacklisted_at": "2023-11-18T08:15:13.112Z"}}, {"model": "token_blacklist.blacklistedtoken", "pk": 11, "fields": {"token": 15, "blacklisted_at": "2023-11-18T08:20:59.010Z"}}, {"model": "users.user", "pk": 1, "fields": {"password": "pbkdf2_sha256$600000$nzZT0y375nTCWEYNVIwug6$VpIS76yZOv/Dx+7I7T7LtLRGLmlZWxaPLDdbQcZonKc=", "username": "teamleader1", "message": null, "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T10:31:15.041Z", "last_login": "2023-11-17T10:31:15.042Z", "groups": [1, 2, 5], "user_permissions": []}}, {"model": "users.user", "pk": 2, "fields": {"password": "pbkdf2_sha256$600000$KTS4WdoLLXRm6PycwmSxYp$sRk81p76jLsBTo+U+IpK5Baw0+F5Y0PvnOfn0YrvZ2M=", "username": "teamleader2", "message": null, "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T10:31:20.237Z", "last_login": "2023-11-17T10:31:20.237Z", "groups": [1, 3], "user_permissions": []}}, {"model": "users.user", "pk": 3, "fields": {"password": "pbkdf2_sha256$600000$4WPfZWoXR7ZWTq5BI7AREs$vLDb8JHrn/r7/pz/MVNLxuzLKG91eP474dP/QxaRzFg=", "username": "teamleader3", "message": null, "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T10:31:22.430Z", "last_login": "2023-11-17T10:31:22.431Z", "groups": [1, 4], "user_permissions": []}}, {"model": "users.user", "pk": 4, "fields": {"password": "pbkdf2_sha256$600000$tIodEq5FQETlxK19IE1Shs$QRM6uJzUbhnVM4MPAj1NWuSz07Gr/KefMJDq7yFDMZk=", "username": "normaluser1", "message": "team:첫번째팀,from:teamleader1", "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T10:34:25.860Z", "last_login": "2023-11-17T10:31:26.614Z", "groups": [], "user_permissions": []}}, {"model": "users.user", "pk": 5, "fields": {"password": "pbkdf2_sha256$600000$Z0Ta7snsyKLOC7IMaBGz7q$FeaAysyefgYuJyshajznYt5fNNbCpf5Nt1Tof4Kt390=", "username": "normaluser2", "message": "team:두번째팀,from:teamleader2", "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T10:34:55.717Z", "last_login": "2023-11-17T10:31:29.058Z", "groups": [], "user_permissions": []}}, {"model": "users.user", "pk": 6, "fields": {"password": "pbkdf2_sha256$600000$Rq7TUznxbIw29e4hB3m5tQ$OX+DWUeYiwsWKci2oE0CuLoIHr5Psk+qJEbGEgz6MsM=", "username": "normaluser3", "message": "team:세번째팀,from:teamleader3", "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T10:35:22.567Z", "last_login": "2023-11-17T10:31:30.940Z", "groups": [], "user_permissions": []}}, {"model": "users.user", "pk": 7, "fields": {"password": "pbkdf2_sha256$600000$seM5g5qSY7a1MrrxgZeV9k$r4kD0kMp1ZHp4nHeEe6zabsmR4FqCoBvkjasExnjyK0=", "username": "normaluser4", "message": null, "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T10:51:25.549Z", "last_login": "2023-11-17T10:51:25.549Z", "groups": [], "user_permissions": []}}, {"model": "users.user", "pk": 8, "fields": {"password": "pbkdf2_sha256$600000$7Cz3STHoiAduBF7mp1JxlS$RJcc7svN1j/vefTZleEppyX9YjSj/6iwPAsUOCd8pOQ=", "username": "normaluser5", "message": null, "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T11:26:23.481Z", "last_login": "2023-11-17T11:12:38.907Z", "groups": [2], "user_permissions": []}}, {"model": "users.user", "pk": 9, "fields": {"password": "pbkdf2_sha256$600000$rMZAnrWycY3UesGO9m7yVJ$VIYwcf/UlJat3Qn0DnfoVNbcIn9PnfMTJMp3J09llDA=", "username": "normaluser6", "message": "team:두번째팀,from:teamleader2", "is_active": true, "is_staff": false, "is_superuser": false, "date_joined": "2023-11-17T11:33:49.706Z", "last_login": "2023-11-17T11:31:47.803Z", "groups": [2], "user_permissions": []}}, {"model": "teams.team", "pk": 1, "fields": {"leader": 1, "name": "첫번째팀", "created_at": "2023-11-17T10:32:11.726Z"}}, {"model": "teams.team", "pk": 2, "fields": {"leader": 2, "name": "두번째팀", "created_at": "2023-11-17T10:33:15.642Z"}}, {"model": "teams.team", "pk": 3, "fields": {"leader": 3, "name": "세번째팀", "created_at": "2023-11-17T10:33:40.616Z"}}, {"model": "teams.team", "pk": 4, "fields": {"leader": 1, "name": "테스트팀", "created_at": "2023-11-18T04:21:27.609Z"}}, {"model": "boards.board", "pk": 1, "fields": {"team": 4}}, {"model": "boards.board", "pk": 2, "fields": {"team": 1}}, {"model": "boards.board", "pk": 3, "fields": {"team": 2}}, {"model": "boards.board", "pk": 4, "fields": {"team": 3}}, {"model": "boards.column", "pk": 1, "fields": {"board": 2, "title": "Backlog", "sequence": 1}}, {"model": "boards.column", "pk": 2, "fields": {"board": 2, "title": "In Progress", "sequence": 1}}, {"model": "boards.column", "pk": 3, "fields": {"board": 2, "title": "Review", "sequence": 1}}, {"model": "boards.column", "pk": 4, "fields": {"board": 1, "title": "Backlog", "sequence": 1}}, {"model": "boards.column", "pk": 5, "fields": {"board": 1, "title": "In Progress", "sequence": 1}}, {"model": "boards.column", "pk": 6, "fields": {"board": 1, "title": "Review", "sequence": 1}}, {"model": "boards.column", "pk": 7, "fields": {"board": 2, "title": "Extra", "sequence": 1}}]
+[
+    {
+        "model": "auth.permission",
+        "pk": 1,
+        "fields": {
+            "name": "Can add log entry",
+            "content_type": 1,
+            "codename": "add_logentry"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 2,
+        "fields": {
+            "name": "Can change log entry",
+            "content_type": 1,
+            "codename": "change_logentry"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 3,
+        "fields": {
+            "name": "Can delete log entry",
+            "content_type": 1,
+            "codename": "delete_logentry"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 4,
+        "fields": {
+            "name": "Can view log entry",
+            "content_type": 1,
+            "codename": "view_logentry"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 5,
+        "fields": {
+            "name": "Can add permission",
+            "content_type": 2,
+            "codename": "add_permission"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 6,
+        "fields": {
+            "name": "Can change permission",
+            "content_type": 2,
+            "codename": "change_permission"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 7,
+        "fields": {
+            "name": "Can delete permission",
+            "content_type": 2,
+            "codename": "delete_permission"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 8,
+        "fields": {
+            "name": "Can view permission",
+            "content_type": 2,
+            "codename": "view_permission"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 9,
+        "fields": {
+            "name": "Can add group",
+            "content_type": 3,
+            "codename": "add_group"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 10,
+        "fields": {
+            "name": "Can change group",
+            "content_type": 3,
+            "codename": "change_group"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 11,
+        "fields": {
+            "name": "Can delete group",
+            "content_type": 3,
+            "codename": "delete_group"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 12,
+        "fields": {
+            "name": "Can view group",
+            "content_type": 3,
+            "codename": "view_group"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 13,
+        "fields": {
+            "name": "Can add content type",
+            "content_type": 4,
+            "codename": "add_contenttype"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 14,
+        "fields": {
+            "name": "Can change content type",
+            "content_type": 4,
+            "codename": "change_contenttype"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 15,
+        "fields": {
+            "name": "Can delete content type",
+            "content_type": 4,
+            "codename": "delete_contenttype"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 16,
+        "fields": {
+            "name": "Can view content type",
+            "content_type": 4,
+            "codename": "view_contenttype"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 17,
+        "fields": {
+            "name": "Can add session",
+            "content_type": 5,
+            "codename": "add_session"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 18,
+        "fields": {
+            "name": "Can change session",
+            "content_type": 5,
+            "codename": "change_session"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 19,
+        "fields": {
+            "name": "Can delete session",
+            "content_type": 5,
+            "codename": "delete_session"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 20,
+        "fields": {
+            "name": "Can view session",
+            "content_type": 5,
+            "codename": "view_session"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 21,
+        "fields": {
+            "name": "Can add blacklisted token",
+            "content_type": 6,
+            "codename": "add_blacklistedtoken"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 22,
+        "fields": {
+            "name": "Can change blacklisted token",
+            "content_type": 6,
+            "codename": "change_blacklistedtoken"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 23,
+        "fields": {
+            "name": "Can delete blacklisted token",
+            "content_type": 6,
+            "codename": "delete_blacklistedtoken"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 24,
+        "fields": {
+            "name": "Can view blacklisted token",
+            "content_type": 6,
+            "codename": "view_blacklistedtoken"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 25,
+        "fields": {
+            "name": "Can add outstanding token",
+            "content_type": 7,
+            "codename": "add_outstandingtoken"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 26,
+        "fields": {
+            "name": "Can change outstanding token",
+            "content_type": 7,
+            "codename": "change_outstandingtoken"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 27,
+        "fields": {
+            "name": "Can delete outstanding token",
+            "content_type": 7,
+            "codename": "delete_outstandingtoken"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 28,
+        "fields": {
+            "name": "Can view outstanding token",
+            "content_type": 7,
+            "codename": "view_outstandingtoken"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 29,
+        "fields": {
+            "name": "Can add user",
+            "content_type": 8,
+            "codename": "add_user"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 30,
+        "fields": {
+            "name": "Can change user",
+            "content_type": 8,
+            "codename": "change_user"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 31,
+        "fields": {
+            "name": "Can delete user",
+            "content_type": 8,
+            "codename": "delete_user"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 32,
+        "fields": {
+            "name": "Can view user",
+            "content_type": 8,
+            "codename": "view_user"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 33,
+        "fields": {
+            "name": "Can add team",
+            "content_type": 9,
+            "codename": "add_team"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 34,
+        "fields": {
+            "name": "Can change team",
+            "content_type": 9,
+            "codename": "change_team"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 35,
+        "fields": {
+            "name": "Can delete team",
+            "content_type": 9,
+            "codename": "delete_team"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 36,
+        "fields": {
+            "name": "Can view team",
+            "content_type": 9,
+            "codename": "view_team"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 37,
+        "fields": {
+            "name": "Can add board",
+            "content_type": 10,
+            "codename": "add_board"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 38,
+        "fields": {
+            "name": "Can change board",
+            "content_type": 10,
+            "codename": "change_board"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 39,
+        "fields": {
+            "name": "Can delete board",
+            "content_type": 10,
+            "codename": "delete_board"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 40,
+        "fields": {
+            "name": "Can view board",
+            "content_type": 10,
+            "codename": "view_board"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 41,
+        "fields": {
+            "name": "Can add column",
+            "content_type": 11,
+            "codename": "add_column"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 42,
+        "fields": {
+            "name": "Can change column",
+            "content_type": 11,
+            "codename": "change_column"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 43,
+        "fields": {
+            "name": "Can delete column",
+            "content_type": 11,
+            "codename": "delete_column"
+        }
+    },
+    {
+        "model": "auth.permission",
+        "pk": 44,
+        "fields": {
+            "name": "Can view column",
+            "content_type": 11,
+            "codename": "view_column"
+        }
+    },
+    {
+        "model": "auth.group",
+        "pk": 1,
+        "fields": { "name": "leader", "permissions": [] }
+    },
+    {
+        "model": "auth.group",
+        "pk": 2,
+        "fields": { "name": "첫번째팀", "permissions": [] }
+    },
+    {
+        "model": "auth.group",
+        "pk": 3,
+        "fields": { "name": "두번째팀", "permissions": [] }
+    },
+    {
+        "model": "auth.group",
+        "pk": 4,
+        "fields": { "name": "세번째팀", "permissions": [] }
+    },
+    {
+        "model": "auth.group",
+        "pk": 5,
+        "fields": { "name": "네번째팀", "permissions": [] }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 1,
+        "fields": { "app_label": "admin", "model": "logentry" }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 2,
+        "fields": { "app_label": "auth", "model": "permission" }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 3,
+        "fields": { "app_label": "auth", "model": "group" }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 4,
+        "fields": { "app_label": "contenttypes", "model": "contenttype" }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 5,
+        "fields": { "app_label": "sessions", "model": "session" }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 6,
+        "fields": {
+            "app_label": "token_blacklist",
+            "model": "blacklistedtoken"
+        }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 7,
+        "fields": {
+            "app_label": "token_blacklist",
+            "model": "outstandingtoken"
+        }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 8,
+        "fields": { "app_label": "users", "model": "user" }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 9,
+        "fields": { "app_label": "teams", "model": "team" }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 10,
+        "fields": { "app_label": "boards", "model": "board" }
+    },
+    {
+        "model": "contenttypes.contenttype",
+        "pk": 11,
+        "fields": { "app_label": "boards", "model": "column" }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 1,
+        "fields": {
+            "user": 1,
+            "jti": "c7194851e8a64a80bcf85440d1546d57",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxMzczNywiaWF0IjoxNzAwMzA0MTM3LCJqdGkiOiJjNzE5NDg1MWU4YTY0YTgwYmNmODU0NDBkMTU0NmQ1NyIsInVzZXJfaWQiOjF9.RQ6zJdxdzAClrP5u8NW_cila6-VYcvGisxTuyab6x8g",
+            "created_at": "2023-11-18T10:42:17.021Z",
+            "expires_at": "2023-12-02T10:42:17Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 2,
+        "fields": {
+            "user": 2,
+            "jti": "7db599ea3fa94acf91cb6b28aa1049f1",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxMzc3MywiaWF0IjoxNzAwMzA0MTczLCJqdGkiOiI3ZGI1OTllYTNmYTk0YWNmOTFjYjZiMjhhYTEwNDlmMSIsInVzZXJfaWQiOjJ9.K8Xr7okECKffumJh0KGhRvNfv7E1ZIeLayl3xh4E6n8",
+            "created_at": "2023-11-18T10:42:53.065Z",
+            "expires_at": "2023-12-02T10:42:53Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 3,
+        "fields": {
+            "user": 3,
+            "jti": "f5d42f8b74cb475c9a1ba91442171176",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxMzc5NCwiaWF0IjoxNzAwMzA0MTk0LCJqdGkiOiJmNWQ0MmY4Yjc0Y2I0NzVjOWExYmE5MTQ0MjE3MTE3NiIsInVzZXJfaWQiOjN9.ilAFX51dFQorLzC0GaN2IOO_FJPBr5X3kTbl1lttzy0",
+            "created_at": "2023-11-18T10:43:14.212Z",
+            "expires_at": "2023-12-02T10:43:14Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 4,
+        "fields": {
+            "user": 4,
+            "jti": "7b7bf0ded1574aa9af6b4068191930c9",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxMzgxOCwiaWF0IjoxNzAwMzA0MjE4LCJqdGkiOiI3YjdiZjBkZWQxNTc0YWE5YWY2YjQwNjgxOTE5MzBjOSIsInVzZXJfaWQiOjR9.qFY6NlPaXqliZf0rmH8e0ZTh5AzV43NLmbO_r4cWOLA",
+            "created_at": "2023-11-18T10:43:38.078Z",
+            "expires_at": "2023-12-02T10:43:38Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 5,
+        "fields": {
+            "user": 1,
+            "jti": "1e27c00a5e534099ae61ae616feebb0d",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxMzg0NywiaWF0IjoxNzAwMzA0MjQ3LCJqdGkiOiIxZTI3YzAwYTVlNTM0MDk5YWU2MWFlNjE2ZmVlYmIwZCIsInVzZXJfaWQiOjF9.bZkYPrSckX64sjw9O2QgjixVpBGWnHlVsa_3UcYbMaU",
+            "created_at": "2023-11-18T10:44:07.328Z",
+            "expires_at": "2023-12-02T10:44:07Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 6,
+        "fields": {
+            "user": 2,
+            "jti": "0189dc028a8041f5857700cd88cfa920",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxMzg5NSwiaWF0IjoxNzAwMzA0Mjk1LCJqdGkiOiIwMTg5ZGMwMjhhODA0MWY1ODU3NzAwY2Q4OGNmYTkyMCIsInVzZXJfaWQiOjJ9.Rh8ekXVo2sROJO7PQbZELHUAD8L3Azj9OBdlzZWXXkw",
+            "created_at": "2023-11-18T10:44:55.122Z",
+            "expires_at": "2023-12-02T10:44:55Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 7,
+        "fields": {
+            "user": 3,
+            "jti": "71211c3136754e9dbca2ceacddc9c92d",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxMzkyMSwiaWF0IjoxNzAwMzA0MzIxLCJqdGkiOiI3MTIxMWMzMTM2NzU0ZTlkYmNhMmNlYWNkZGM5YzkyZCIsInVzZXJfaWQiOjN9.fUAvmghZT6cLnCSdCLOrUHWkZu3jd_v8FcMh_E_4a5I",
+            "created_at": "2023-11-18T10:45:21.396Z",
+            "expires_at": "2023-12-02T10:45:21Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 8,
+        "fields": {
+            "user": 6,
+            "jti": "1c27778604b943928d85d33bcaa61574",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxMzk5OCwiaWF0IjoxNzAwMzA0Mzk4LCJqdGkiOiIxYzI3Nzc4NjA0Yjk0MzkyOGQ4NWQzM2JjYWE2MTU3NCIsInVzZXJfaWQiOjZ9.BxnEy5eiEMXhHq6UR6SqLWHzS19euYA27WTYV-CIBQE",
+            "created_at": "2023-11-18T10:46:38.089Z",
+            "expires_at": "2023-12-02T10:46:38Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 9,
+        "fields": {
+            "user": 7,
+            "jti": "85355261fcfa47e98574da191b8a2629",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDAyNiwiaWF0IjoxNzAwMzA0NDI2LCJqdGkiOiI4NTM1NTI2MWZjZmE0N2U5ODU3NGRhMTkxYjhhMjYyOSIsInVzZXJfaWQiOjd9.L2FxbnOPQZ1NPlc3FeTC_0Z4sNQh3csf04x27cS3moM",
+            "created_at": "2023-11-18T10:47:06.433Z",
+            "expires_at": "2023-12-02T10:47:06Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 10,
+        "fields": {
+            "user": 8,
+            "jti": "da585590c48143499b99e27271b88894",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDA0MywiaWF0IjoxNzAwMzA0NDQzLCJqdGkiOiJkYTU4NTU5MGM0ODE0MzQ5OWI5OWUyNzI3MWI4ODg5NCIsInVzZXJfaWQiOjh9.QdeK2_mfAF84ifFOIvSsvx-Gj-0RUq7M3Or3ETF_1PY",
+            "created_at": "2023-11-18T10:47:23.232Z",
+            "expires_at": "2023-12-02T10:47:23Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 11,
+        "fields": {
+            "user": 1,
+            "jti": "4c3ebdd6887d487798e5e252bdf8850d",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDA4MywiaWF0IjoxNzAwMzA0NDgzLCJqdGkiOiI0YzNlYmRkNjg4N2Q0ODc3OThlNWUyNTJiZGY4ODUwZCIsInVzZXJfaWQiOjF9.LyFAssJIChc09fxAZRI1nyF0EKzBrebw2kkIc95vbIs",
+            "created_at": "2023-11-18T10:48:03.232Z",
+            "expires_at": "2023-12-02T10:48:03Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 12,
+        "fields": {
+            "user": 10,
+            "jti": "5a8c89077d3b4179ac80c329f86d4bce",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDEyMSwiaWF0IjoxNzAwMzA0NTIxLCJqdGkiOiI1YThjODkwNzdkM2I0MTc5YWM4MGMzMjlmODZkNGJjZSIsInVzZXJfaWQiOjEwfQ.vxCwoFEpoqTxJzdGEIPZMs6fgt7cAokZbSirT5AebVU",
+            "created_at": "2023-11-18T10:48:41.909Z",
+            "expires_at": "2023-12-02T10:48:41Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 13,
+        "fields": {
+            "user": 1,
+            "jti": "c5358e3d40464230b06df84b53cb2d11",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDE1MCwiaWF0IjoxNzAwMzA0NTUwLCJqdGkiOiJjNTM1OGUzZDQwNDY0MjMwYjA2ZGY4NGI1M2NiMmQxMSIsInVzZXJfaWQiOjF9.N-_gSpdR47QGyLEnxOE7fwXF_1KB8MjDy8q2nMvjTos",
+            "created_at": "2023-11-18T10:49:10.319Z",
+            "expires_at": "2023-12-02T10:49:10Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 14,
+        "fields": {
+            "user": 11,
+            "jti": "9edba900b43e4fe695b24e950616118f",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDE4NSwiaWF0IjoxNzAwMzA0NTg1LCJqdGkiOiI5ZWRiYTkwMGI0M2U0ZmU2OTViMjRlOTUwNjE2MTE4ZiIsInVzZXJfaWQiOjExfQ.ucb-Z7zbSpqLq_tTzMsoFItKIQ4a8JnlSdBdbLlkpzA",
+            "created_at": "2023-11-18T10:49:45.010Z",
+            "expires_at": "2023-12-02T10:49:45Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 15,
+        "fields": {
+            "user": 1,
+            "jti": "9a73620fd4424078afe99f6f1a19129c",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDIwMiwiaWF0IjoxNzAwMzA0NjAyLCJqdGkiOiI5YTczNjIwZmQ0NDI0MDc4YWZlOTlmNmYxYTE5MTI5YyIsInVzZXJfaWQiOjF9.KTh9nP3MiO1I-WSlXr4pgksOLa0wQxqdx45VYiEBtwg",
+            "created_at": "2023-11-18T10:50:02.540Z",
+            "expires_at": "2023-12-02T10:50:02Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 16,
+        "fields": {
+            "user": 2,
+            "jti": "5261721cb8974412895730c271bc8c37",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDIyNywiaWF0IjoxNzAwMzA0NjI3LCJqdGkiOiI1MjYxNzIxY2I4OTc0NDEyODk1NzMwYzI3MWJjOGMzNyIsInVzZXJfaWQiOjJ9.GWiSkEbiZCsEIagbAPjrJMvylSf6jjL_PAyl3dUOguc",
+            "created_at": "2023-11-18T10:50:27.606Z",
+            "expires_at": "2023-12-02T10:50:27Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 17,
+        "fields": {
+            "user": 11,
+            "jti": "a785ae8a4f6c4023afec31ebc78d31a2",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDI4MywiaWF0IjoxNzAwMzA0NjgzLCJqdGkiOiJhNzg1YWU4YTRmNmM0MDIzYWZlYzMxZWJjNzhkMzFhMiIsInVzZXJfaWQiOjExfQ.xSnCrCSoy9uPVUFthBWrEuL1uXQGg2O4GvlOFRbVXCw",
+            "created_at": "2023-11-18T10:51:23.536Z",
+            "expires_at": "2023-12-02T10:51:23Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 18,
+        "fields": {
+            "user": 1,
+            "jti": "246eedc04a924ae1a1a4bd5182464eb2",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDM0NiwiaWF0IjoxNzAwMzA0NzQ2LCJqdGkiOiIyNDZlZWRjMDRhOTI0YWUxYTFhNGJkNTE4MjQ2NGViMiIsInVzZXJfaWQiOjF9.s0Ol0tanwRjJCb6Y3P7_wx4x9tH7VgZahDQfIRVjdgQ",
+            "created_at": "2023-11-18T10:52:26.686Z",
+            "expires_at": "2023-12-02T10:52:26Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 19,
+        "fields": {
+            "user": 11,
+            "jti": "30afb090fe444327a08606cd27cd69ff",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDkwOCwiaWF0IjoxNzAwMzA1MzA4LCJqdGkiOiIzMGFmYjA5MGZlNDQ0MzI3YTA4NjA2Y2QyN2NkNjlmZiIsInVzZXJfaWQiOjExfQ.aXFBLzdZYRjbuHiXnhwyRKHd8YAkWWTETM1o12fqA9w",
+            "created_at": "2023-11-18T11:01:48.954Z",
+            "expires_at": "2023-12-02T11:01:48Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 20,
+        "fields": {
+            "user": 2,
+            "jti": "0114090cd87344798a11fec5808282c5",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDk0NSwiaWF0IjoxNzAwMzA1MzQ1LCJqdGkiOiIwMTE0MDkwY2Q4NzM0NDc5OGExMWZlYzU4MDgyODJjNSIsInVzZXJfaWQiOjJ9.twRF_j-BdrFu_5JmBJ_nW-odmfR10phMUJmTETQzS-A",
+            "created_at": "2023-11-18T11:02:25.032Z",
+            "expires_at": "2023-12-02T11:02:25Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 21,
+        "fields": {
+            "user": 1,
+            "jti": "98c37671d1d846bf84a72ecf671b1e86",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNDk5NywiaWF0IjoxNzAwMzA1Mzk3LCJqdGkiOiI5OGMzNzY3MWQxZDg0NmJmODRhNzJlY2Y2NzFiMWU4NiIsInVzZXJfaWQiOjF9.qtiVdq9a8kM1kJEl1u6BOOAXoFfPl2cxId3L4a429k4",
+            "created_at": "2023-11-18T11:03:17.382Z",
+            "expires_at": "2023-12-02T11:03:17Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 22,
+        "fields": {
+            "user": 2,
+            "jti": "aff79ad20d694f529ce0bb7a33285a94",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNTA0NiwiaWF0IjoxNzAwMzA1NDQ2LCJqdGkiOiJhZmY3OWFkMjBkNjk0ZjUyOWNlMGJiN2EzMzI4NWE5NCIsInVzZXJfaWQiOjJ9.31XuATLXdIgujs2FBZc5ljWqBFnn5tsdmm85zfTnaUI",
+            "created_at": "2023-11-18T11:04:06.752Z",
+            "expires_at": "2023-12-02T11:04:06Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 23,
+        "fields": {
+            "user": 1,
+            "jti": "ce090d8affba41e28b87e321a45d7aa2",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNTIzMSwiaWF0IjoxNzAwMzA1NjMxLCJqdGkiOiJjZTA5MGQ4YWZmYmE0MWUyOGI4N2UzMjFhNDVkN2FhMiIsInVzZXJfaWQiOjF9.oXA2grYwyMOdD5LRtlifZskTw1XtSk595gs5fbkhYDg",
+            "created_at": "2023-11-18T11:07:11.520Z",
+            "expires_at": "2023-12-02T11:07:11Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 24,
+        "fields": {
+            "user": 1,
+            "jti": "cd63401e1fab4919baf08a9159ab5ff0",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNTYxMSwiaWF0IjoxNzAwMzA2MDExLCJqdGkiOiJjZDYzNDAxZTFmYWI0OTE5YmFmMDhhOTE1OWFiNWZmMCIsInVzZXJfaWQiOjF9.I44w8MIplXro5h2mzw4lwWqX1GE6hgEsOAzevVeKZ7I",
+            "created_at": "2023-11-18T11:13:31.077Z",
+            "expires_at": "2023-12-02T11:13:31Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 25,
+        "fields": {
+            "user": 1,
+            "jti": "0c9f50d04363411b94e9aeeb1d26e8be",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNjk0NSwiaWF0IjoxNzAwMzA3MzQ1LCJqdGkiOiIwYzlmNTBkMDQzNjM0MTFiOTRlOWFlZWIxZDI2ZThiZSIsInVzZXJfaWQiOjF9.Vi73S_bfwULgv6q662HzMQ1Zm9LGKlisiCEn8fGLmb0",
+            "created_at": "2023-11-18T11:35:45.965Z",
+            "expires_at": "2023-12-02T11:35:45Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 26,
+        "fields": {
+            "user": 1,
+            "jti": "72b5087576a441ddb45bc622191b49d4",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUxNzMwNiwiaWF0IjoxNzAwMzA3NzA2LCJqdGkiOiI3MmI1MDg3NTc2YTQ0MWRkYjQ1YmM2MjIxOTFiNDlkNCIsInVzZXJfaWQiOjF9.nhHaGc1iDNOLiraNy3UeIkLpjejjgjEStHIyP5sPVlk",
+            "created_at": "2023-11-18T11:41:46.369Z",
+            "expires_at": "2023-12-02T11:41:46Z"
+        }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 1,
+        "fields": { "token": 1, "blacklisted_at": "2023-11-18T10:42:48.250Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 2,
+        "fields": { "token": 2, "blacklisted_at": "2023-11-18T10:43:09.382Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 3,
+        "fields": { "token": 3, "blacklisted_at": "2023-11-18T10:43:33.477Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 4,
+        "fields": { "token": 4, "blacklisted_at": "2023-11-18T10:43:54.031Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 5,
+        "fields": { "token": 5, "blacklisted_at": "2023-11-18T10:44:51.256Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 6,
+        "fields": { "token": 6, "blacklisted_at": "2023-11-18T10:45:15.719Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 7,
+        "fields": { "token": 7, "blacklisted_at": "2023-11-18T10:45:42.396Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 8,
+        "fields": { "token": 8, "blacklisted_at": "2023-11-18T10:47:02.129Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 9,
+        "fields": { "token": 9, "blacklisted_at": "2023-11-18T10:47:18.979Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 10,
+        "fields": { "token": 10, "blacklisted_at": "2023-11-18T10:47:44.999Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 11,
+        "fields": { "token": 11, "blacklisted_at": "2023-11-18T10:48:32.064Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 12,
+        "fields": { "token": 12, "blacklisted_at": "2023-11-18T10:49:00.699Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 13,
+        "fields": { "token": 13, "blacklisted_at": "2023-11-18T10:49:34.505Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 14,
+        "fields": { "token": 14, "blacklisted_at": "2023-11-18T10:49:57.715Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 15,
+        "fields": { "token": 15, "blacklisted_at": "2023-11-18T10:50:21.312Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 16,
+        "fields": { "token": 16, "blacklisted_at": "2023-11-18T10:50:47.528Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 17,
+        "fields": { "token": 17, "blacklisted_at": "2023-11-18T10:52:19.344Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 18,
+        "fields": { "token": 18, "blacklisted_at": "2023-11-18T11:01:38.790Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 19,
+        "fields": { "token": 19, "blacklisted_at": "2023-11-18T11:02:13.240Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 20,
+        "fields": { "token": 20, "blacklisted_at": "2023-11-18T11:02:43.205Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 21,
+        "fields": { "token": 21, "blacklisted_at": "2023-11-18T11:04:02.672Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 22,
+        "fields": { "token": 22, "blacklisted_at": "2023-11-18T11:04:40.057Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 23,
+        "fields": { "token": 23, "blacklisted_at": "2023-11-18T11:08:04.432Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 24,
+        "fields": { "token": 24, "blacklisted_at": "2023-11-18T11:14:02.735Z" }
+    },
+    {
+        "model": "users.user",
+        "pk": 1,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$o2ck7loBHkZ6vta4H3ZCtD$dNYzwKOV38yvsvk47eJB2LaZc4PUafTyj5b95dD9zwk=",
+            "username": "teamleader1",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:41:01.718Z",
+            "last_login": "2023-11-18T10:41:01.718Z",
+            "groups": [1, 2],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 2,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$tejUWvi9xT2tRtZetjOznU$Ekt2T3iX80lvWhEj9u1F8Lh4Bn6H4jTx2wPdaOCRMAo=",
+            "username": "teamleader2",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:41:04.673Z",
+            "last_login": "2023-11-18T10:41:04.673Z",
+            "groups": [1, 3],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 3,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$NuZp8DcDUOmBThVnfQHNWX$Cf9z8UUrz9KtjmP0T6DDm3mL0gPDsd9mE65sFvgtIyA=",
+            "username": "teamleader3",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:41:07.061Z",
+            "last_login": "2023-11-18T10:41:07.062Z",
+            "groups": [1, 4],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 4,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$eSR9V8akNxqVlLDOyJBLRT$XAH4IvTufzpGfbJorD2MUDV8tytUOvb3Bknj1uGNPMc=",
+            "username": "teamleader4",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:41:09.273Z",
+            "last_login": "2023-11-18T10:41:09.273Z",
+            "groups": [1, 5],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 5,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$DZvLE6eFObVE7JrFVK2Zpv$P3EnjRNTw9xLpK0NeiOOmgImWCA7LasGKaJvdf+l/UA=",
+            "username": "teamleader5",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:41:11.535Z",
+            "last_login": "2023-11-18T10:41:11.535Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 6,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$KuUrFFdwzOYzo9cyfbIerW$gQxYNnoPToCDPm5X9Far/4kRb23BDwHsBqA15z8XMao=",
+            "username": "normaluser1",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:46:54.064Z",
+            "last_login": "2023-11-18T10:41:15.764Z",
+            "groups": [2],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 7,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$2fWpcMcJBMyfRiic5g37g9$Z86aK+q74yJwxEOtYdqN5qPUYcSy+BHBZIfvkNB8ABk=",
+            "username": "normaluser2",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:47:14.162Z",
+            "last_login": "2023-11-18T10:41:17.769Z",
+            "groups": [3],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 8,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$ekZrvGLA1TWaBvtQ6gGwsH$zGbd0iaLkmeiLm+ei5G0l4NXEJiW08/1DnNRC3SQqy4=",
+            "username": "normaluser3",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:47:34.284Z",
+            "last_login": "2023-11-18T10:41:19.795Z",
+            "groups": [4],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 9,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$asfstegjor9YjvtiLtD4vZ$Q598R+jOTFlUJJnt9JmIF+KS8s3lB3LIekdny3WZoTs=",
+            "username": "normaluser4",
+            "message": null,
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T10:41:22.180Z",
+            "last_login": "2023-11-18T10:41:22.180Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 10,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$wudcX475PyfvfDBV5QARhX$HBynh6+phmR5KT6VQs/KvQ1ueXvxfJOHw0zioIBYyKw=",
+            "username": "normaluser5",
+            "message": "team:첫번째팀,from:teamleader1",
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T11:13:51.181Z",
+            "last_login": "2023-11-18T10:41:34.571Z",
+            "groups": [2],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 11,
+        "fields": {
+            "password": "pbkdf2_sha256$600000$hOR2LZaJla9ZrvxWAbBj4w$MiLPM3s5BfHB18ibOQUzWjZ2zIt8T/i+fErGeGORgJs=",
+            "username": "normaluser6",
+            "message": "team:두번째팀,from:teamleader2",
+            "is_active": true,
+            "is_staff": false,
+            "is_superuser": false,
+            "date_joined": "2023-11-18T11:02:37.393Z",
+            "last_login": "2023-11-18T10:42:05.957Z",
+            "groups": [2],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "teams.team",
+        "pk": 1,
+        "fields": {
+            "leader": 1,
+            "name": "첫번째팀",
+            "created_at": "2023-11-18T10:42:39.981Z"
+        }
+    },
+    {
+        "model": "teams.team",
+        "pk": 2,
+        "fields": {
+            "leader": 2,
+            "name": "두번째팀",
+            "created_at": "2023-11-18T10:43:03.950Z"
+        }
+    },
+    {
+        "model": "teams.team",
+        "pk": 3,
+        "fields": {
+            "leader": 3,
+            "name": "세번째팀",
+            "created_at": "2023-11-18T10:43:29.006Z"
+        }
+    },
+    {
+        "model": "teams.team",
+        "pk": 4,
+        "fields": {
+            "leader": 4,
+            "name": "네번째팀",
+            "created_at": "2023-11-18T10:43:49.455Z"
+        }
+    },
+    { "model": "boards.board", "pk": 1, "fields": { "team": 1 } },
+    { "model": "boards.board", "pk": 2, "fields": { "team": 2 } },
+    { "model": "boards.board", "pk": 3, "fields": { "team": 3 } },
+    { "model": "boards.board", "pk": 4, "fields": { "team": 4 } },
+    {
+        "model": "boards.column",
+        "pk": 1,
+        "fields": { "board": 1, "title": "Backlog", "sequence": 1 }
+    },
+    {
+        "model": "boards.column",
+        "pk": 2,
+        "fields": { "board": 1, "title": "In Progress", "sequence": 2 }
+    },
+    {
+        "model": "boards.column",
+        "pk": 3,
+        "fields": { "board": 1, "title": "Review", "sequence": 3 }
+    },
+    {
+        "model": "boards.column",
+        "pk": 4,
+        "fields": { "board": 2, "title": "Backlog", "sequence": 1 }
+    },
+    {
+        "model": "boards.column",
+        "pk": 5,
+        "fields": { "board": 2, "title": "In Progress", "sequence": 2 }
+    },
+    {
+        "model": "boards.column",
+        "pk": 6,
+        "fields": { "board": 2, "title": "Review", "sequence": 3 }
+    }
+]

--- a/swagger.py
+++ b/swagger.py
@@ -31,3 +31,11 @@ TEAM_INVITE_PARAMETERS = openapi.Schema(
         'team': openapi.Schema(type=openapi.TYPE_STRING, description='초대하는 팀명')
     }
 )
+
+COLUMN_CREATE_PARAMETER = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'team': openapi.Schema(type=openapi.TYPE_STRING, description='팀명'),
+        'title': openapi.Schema(type=openapi.TYPE_STRING, description='컬럼 제목')
+    }
+)

--- a/teams/permissions.py
+++ b/teams/permissions.py
@@ -1,13 +1,29 @@
 from rest_framework.permissions import BasePermission
 
+from rest_framework.response import Response
+from rest_framework import status
 
-# 팀 초대 기능은 팀장만 가능하므로
+from django.core.exceptions import ObjectDoesNotExist
+
+from teams.models import Team
+
+
+# 팀 초대 기능은 해당 팀의 팀장만 가능하므로
 # 관련 권한 정의
 class CanInviteTeamPermission(BasePermission):
     def has_permission(self, request, view):
         # 사용자 가져오기
         user = request.user
 
-        # 팀장만 초대 가능
-        # 팀장이다 → True / 팀장이 아니다 → False
-        return user.groups.filter(name='leader').exists()
+        try:
+            # 팀 가져오기
+            team = Team.objects.get(
+                name=request.data.get('team')
+            )
+        # 만약 팀명을 입력하지 않은 상황이라면 상태 코드 반환
+        except ObjectDoesNotExist as error:
+            return Response({'data': f'{error}'}, status=status.HTTP_400_BAD_REQUEST)
+
+        # 해당 팀의 팀장만 초대 가능
+        # 해당 팀의 팀장이다 → True / 그 외 → False
+        return (user.groups.filter(name='leader').exists()) and (team.leader == user)

--- a/teams/tests.py
+++ b/teams/tests.py
@@ -134,7 +134,7 @@ class TeamInviteTestCase(APITestCase):
         # APIClient 객체에 인증 진행
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
 
-        #  타켓 사용자 미입력
+        #  타겟 사용자 미입력
         request_data = {
             'team': '첫번째팀',
         }
@@ -194,7 +194,7 @@ class TeamInviteTestCase(APITestCase):
 
         # 이미 초대된 사용자를 초대
         request_data = {
-            'target': 'normaluser1',
+            'target': 'normaluser5',
             'team': '첫번째팀',
         }
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -331,9 +331,9 @@ class UserInviteReadTestCase(APITestCase):
 
     # 팀 초대 메시지가 있는 케이스
     def test_message_exist(self):
-        # 기존 DB의 사용자 중 팀 초대를 받은 팀장이 아닌 사용자로 로그인
+        # 기존 DB의 사용자 중 팀 초대를 받은 / 팀장이 아닌 사용자로 로그인
         login_data = {
-            'username': 'normaluser1',
+            'username': 'normaluser5',
             'password': 'qwerty123!@#'
         }
 
@@ -405,9 +405,9 @@ class UserInviteAcceptTestCase(APITestCase):
 
     # 받아들일 팀 초대 메시지가 있는 케이스
     def test_default(self):
-        # 기존 DB의 사용자 중 팀 초대를 받은 팀장이 아닌 사용자로 로그인
+        # 기존 DB의 사용자 중 팀 초대를 받은, 팀장이 아닌 사용자로 로그인
         login_data = {
-            'username': 'normaluser1',
+            'username': 'normaluser5',
             'password': 'qwerty123!@#'
         }
 


### PR DESCRIPTION
## 반영 브랜치

feature/boards/#37 → develop


## 변경 사항

컬럼 목록 확인 기능을 생성했습니다.

처음에는 정확하게 컬럼에 관한 데이터만 반환하는 기능으로 만들고자 하였으나, 컬럼이나 티켓 단위로 데이터를 제공하는 것 보다는 보드 단위로 데이터를 한번에 제공하는 편이 API 사용에 편리할 것이라는 판단으로 보드 전체를 반환하도록 구성했습니다. 현재는 팀명과 컬럼명, 컬럼 순서가 반환됩니다.

현재 로그인한 사용자가 자신이 속한 팀의 보드를 확인할 수 있도록 만들었습니다. 만약 팀에 소속되지 않은 사용자가 접근을 시도할 경우에는 권한 문제로 상태코드 403을, 인증되지 않은 사용자가 접근을 시도할 경우에는 인증 문제로 상태코드 401을 반환합니다.

시리얼라이저를 활용하여 보드 목록 기능을 구현하였습니다. 시리얼라이저에 팀명과 컬럼 필드를 시리얼라이저 메서드 필드로 생성한 다음 팀명과 컬럼명, 컬럼 순서가 JSON 형태로 반환될 수 있도록 만들었습니다.

여러 상황에 대한 테스트 코드를 작성하고 의도한대로 작동하는 것을 확인했습니다.