### PR TITLE
[기능 생성] 컬럼 순서 수정 기능 생성

### DIFF
--- a/boards/tests.py
+++ b/boards/tests.py
@@ -151,7 +151,7 @@ class ColumnUpdateTestCase(APITestCase):
         response = self.client.put(self.url, request_data)
 
         self.assertEqual(
-            response.status_code, status.HTTP_202_ACCEPTED, response.data
+            response.status_code, status.HTTP_200_OK, response.data
         )
 
     # 컬럼 id 없이 수정을 시도하는 케이스
@@ -207,7 +207,7 @@ class ColumnUpdateTestCase(APITestCase):
         response = self.client.put(self.url, request_data)
 
         self.assertEqual(
-            response.status_code, status.HTTP_202_ACCEPTED, response.data
+            response.status_code, status.HTTP_200_OK, response.data
         )
 
     # 수정할 데이터 없이 수정을 시도하는 케이스
@@ -365,6 +365,291 @@ class ColumnUpdateTestCase(APITestCase):
         response = self.client.put(self.url, request_data)
 
         # 인증된 사용자에게 권한을 부여하므로, 인증되지 않으면 사용 불가
+        self.assertEqual(
+            response.status_code, status.HTTP_401_UNAUTHORIZED, response.data
+        )
+
+
+# 컬럼 순서 수정 테스트
+class ColumnSequenceUpdateTestCase(APITestCase):
+    fixtures = ['db.json']
+
+    def setUp(self):
+        # APIClient 객체 생성
+        self.client = APIClient()
+
+        # /api/v1/boards/column/update/sequence/
+        self.url = reverse('column_sequence_update')
+
+    # 컬럼 순서가 기존보다 뒤로 가는 케이스
+    def test_sequence_right(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 1,
+            'sequence': 3
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, response.data
+        )
+
+    # 컬럼 순서가 기존보다 앞으로 가는 케이스
+    def test_sequence_left(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 3,
+            'sequence': 2
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, response.data
+        )
+
+    # 원래 값을 변경 값으로 받은 케이스
+    def test_sequence_stand(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 2,
+            'sequence': 2
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        # 값이 변할 건 없으므로 상태코드 200
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, response.data
+        )
+
+    # 유효하지 않은 컬럼 id 값을 받은 케이스
+    def test_invalid_column(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 'INVALID',
+            'sequence': 2
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 유효하지 않은 변경 값을 받은 케이스
+    def test_invalid_sequence(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 1,
+            'sequence': 'INVALID'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 0 이하의 순서값을 받은 케이스
+    def test_sequence_under_0(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 1,
+            'sequence': 0
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 현재 보드 내 컬럼 갯수보다 큰 순서값을 받은 케이스
+    def test_sequence_over_len(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 1,
+            'sequence': 100
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 입력값이 없는 케이스
+    def test_sequence_no_data(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 데이터가 없음
+        request_data = {}
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 권한이 없는(소속된 팀이 없는) 케이스
+    def test_no_permission(self):
+        # 기존 DB의 사용자 중 팀이 없는 사용자로 로그인 시도
+        login_data = {
+            'username': 'normaluser4',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 1,
+            'sequence': 3
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_403_FORBIDDEN, response.data
+        )
+
+    # 인증이 없는(로그인이 되지 않은) 케이스
+    def test_no_authorize(self):
+        # 컬럼 순서 수정에 필요한 데이터 생성
+        request_data = {
+            'column': 1,
+            'sequence': 3
+        }
+
+        response = self.client.put(self.url, request_data)
+
         self.assertEqual(
             response.status_code, status.HTTP_401_UNAUTHORIZED, response.data
         )

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -3,7 +3,8 @@ from django.urls import path
 from .views import (
     BoardListView,
     ColumnCreateView,
-    ColumnUpdateView
+    ColumnUpdateView,
+    ColumnUpdateSequenceView
 )
 
 
@@ -11,4 +12,9 @@ urlpatterns = [
     path('board/list/', BoardListView.as_view(), name='board_list'),
     path('column/create/', ColumnCreateView.as_view(), name='column_create'),
     path('column/update/', ColumnUpdateView.as_view(), name='column_update'),
+    path(
+        'column/update/sequence/',
+        ColumnUpdateSequenceView.as_view(),
+        name='column_sequence_update'
+    ),
 ]

--- a/db.json
+++ b/db.json
@@ -768,6 +768,39 @@
         }
     },
     {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 27,
+        "fields": {
+            "user": 1,
+            "jti": "d0ebff06e2e04ec89871dfe3aa3c3d0a",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUyMDk0MywiaWF0IjoxNzAwMzExMzQzLCJqdGkiOiJkMGViZmYwNmUyZTA0ZWM4OTg3MWRmZTNhYTNjM2QwYSIsInVzZXJfaWQiOjF9.8Mcydq2y4r_teH3tVFxdiApFtoBeMS_ta96lgEAAMWI",
+            "created_at": "2023-11-18T12:42:23.346Z",
+            "expires_at": "2023-12-02T12:42:23Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 28,
+        "fields": {
+            "user": 1,
+            "jti": "72bb5a40a281413284f41a7a08e337d0",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUyNjE2MywiaWF0IjoxNzAwMzE2NTYzLCJqdGkiOiI3MmJiNWE0MGEyODE0MTMyODRmNDFhN2EwOGUzMzdkMCIsInVzZXJfaWQiOjF9.3lArxT-04_ZwClhcxxXMZqeD5uod2rILMlAKMupQZKA",
+            "created_at": "2023-11-18T14:09:23.918Z",
+            "expires_at": "2023-12-02T14:09:23Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 29,
+        "fields": {
+            "user": 1,
+            "jti": "1c692b2a4cf74291814baa97c29ad700",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTUzMzE5NSwiaWF0IjoxNzAwMzIzNTk1LCJqdGkiOiIxYzY5MmIyYTRjZjc0MjkxODE0YmFhOTdjMjlhZDcwMCIsInVzZXJfaWQiOjF9.w1jBkJtwXt7TuuUu5JwQWl7Pi3z-Oa2CrvU5-watYr4",
+            "created_at": "2023-11-18T16:06:35.645Z",
+            "expires_at": "2023-12-02T16:06:35Z"
+        }
+    },
+    {
         "model": "token_blacklist.blacklistedtoken",
         "pk": 1,
         "fields": { "token": 1, "blacklisted_at": "2023-11-18T10:42:48.250Z" }
@@ -886,6 +919,11 @@
         "model": "token_blacklist.blacklistedtoken",
         "pk": 24,
         "fields": { "token": 24, "blacklisted_at": "2023-11-18T11:14:02.735Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 25,
+        "fields": { "token": 27, "blacklisted_at": "2023-11-18T12:43:24.654Z" }
     },
     {
         "model": "users.user",
@@ -1121,7 +1159,7 @@
     {
         "model": "boards.column",
         "pk": 4,
-        "fields": { "board": 2, "title": "Backlog", "sequence": 1 }
+        "fields": { "board": 2, "title": "Backlog", "sequence": 2 }
     },
     {
         "model": "boards.column",
@@ -1132,5 +1170,10 @@
         "model": "boards.column",
         "pk": 6,
         "fields": { "board": 2, "title": "Review", "sequence": 3 }
+    },
+    {
+        "model": "boards.column",
+        "pk": 7,
+        "fields": { "board": 1, "title": "Extra", "sequence": 4 }
     }
 ]

--- a/swagger.py
+++ b/swagger.py
@@ -1,6 +1,16 @@
 from drf_yasg import openapi
 
 
+SUCCESS_MESSAGE_200 = '성공적으로 요청을 완료했습니다.'
+SUCCESS_MESSAGE_201 = '성공적으로 데이터 생성을 완료했습니다.'
+SUCCESS_MESSAGE_204 = '성공적으로 요청을 완료했습니다. 그러나 반환할 값이 없습니다.'
+ERROR_MESSAGE_400 = '입력값 오류, 잘못된 값이 입력되었습니다. 상세한 내용은 에러 메시지를 확인해주세요.'
+ERROR_MESSAGE_401 = '인증 오류, 인증되지 않은 사용자는 이용할 수 없습니다.'
+ERROR_MESSAGE_403 = '권한 오류, 권한이 없는 사용자는 이용할 수 없습니다.'
+ERROR_MESSAGE_404 = '입력값 오류, 잘못된 값으로 인해 데이터를 찾을 수 없습니다.'
+ERROR_MESSAGE_423 = '상태 오류, 요청이 완료될 수 없는 상태입니다.'
+ERROR_MESSAGE_500 = '서버 오류, 요청을 처리하던 중 서버에 문제가 발생했습니다.'
+
 USER_REGISTER_PARAMETERS = openapi.Schema(
     type=openapi.TYPE_OBJECT,
     properties={
@@ -37,5 +47,21 @@ COLUMN_CREATE_PARAMETER = openapi.Schema(
     properties={
         'team': openapi.Schema(type=openapi.TYPE_STRING, description='팀명'),
         'title': openapi.Schema(type=openapi.TYPE_STRING, description='컬럼 제목')
+    }
+)
+
+COLUMN_UPDATE_PARAMETER = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'column': openapi.Schema(type=openapi.TYPE_INTEGER, description='컬럼 id'),
+        'title': openapi.Schema(type=openapi.TYPE_STRING, description='컬럼 제목')
+    }
+)
+
+COLUMN_UPDATE_SEQUENCE_PARAMETER = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'column': openapi.Schema(type=openapi.TYPE_INTEGER, description='컬럼 id'),
+        'sequence': openapi.Schema(type=openapi.TYPE_STRING, description='컬럼 순서')
     }
 )

--- a/teams/views.py
+++ b/teams/views.py
@@ -17,7 +17,7 @@ from boards.models import Board
 from .models import Team
 from .serializers import TeamCreateSerializer
 
-from swagger import TEAM_CREATE_PARAMETERS, TEAM_INVITE_PARAMETERS
+from swagger import *
 
 
 # /api/v1/teams/create/
@@ -31,10 +31,10 @@ class TeamCreateView(APIView):
         tags=['팀', '생성'],
         request_body=TEAM_CREATE_PARAMETERS,
         responses={
-            201: '팀 생성이 성공적으로 완료되었습니다.',
-            400: '팀 생성 중 에러가 발생했습니다. 입력된 값을 확인해주세요.',
-            401: '인증되지 않은 사용자는 사용할 수 없습니다.',
-            500: '데이터를 DB에 저장하던 중 문제가 발생했습니다.'
+            201: SUCCESS_MESSAGE_201,
+            400: ERROR_MESSAGE_400,
+            401: ERROR_MESSAGE_401,
+            500: ERROR_MESSAGE_500
         }
     )
     def post(self, request):
@@ -126,11 +126,11 @@ class TeamInviteView(APIView):
         tags=['팀', '초대'],
         request_body=TEAM_INVITE_PARAMETERS,
         responses={
-            200: '성공적으로 작업을 완료했습니다.',
-            401: '로그인 후 사용해주세요.',
-            403: '팀 초대는 해당 팀의 팀장만 가능합니다.',
-            404: '해당하는 사용자나 팀을 찾을 수 없습니다. 입력값을 다시 확인해주세요.',
-            423: '해당 사용자는 초대 가능한 상태가 아닙니다.'
+            200: SUCCESS_MESSAGE_200,
+            401: ERROR_MESSAGE_401,
+            403: ERROR_MESSAGE_403,
+            404: ERROR_MESSAGE_404,
+            423: ERROR_MESSAGE_423
         }
     )
     def post(self, request):

--- a/users/tests.py
+++ b/users/tests.py
@@ -404,7 +404,7 @@ class UserInviteAcceptTestCase(APITestCase):
         response = self.client.post(self.url)
 
         self.assertEqual(
-            response.status_code, status.HTTP_202_ACCEPTED, response.data
+            response.status_code, status.HTTP_200_OK, response.data
         )
 
     # 받아들일 팀 초대 메시지가 없는 케이스
@@ -453,9 +453,9 @@ class UserInviteAcceptTestCase(APITestCase):
         response = self.client.post(self.url)
 
         # 사용자에게서 기존 팀 그룹을 삭제하고 새 팀 그룹을 추가하게 되므로
-        # 상태 코드는 202
+        # 상태 코드는 200
         self.assertEqual(
-            response.status_code, status.HTTP_202_ACCEPTED, response.data
+            response.status_code, status.HTTP_200_OK, response.data
         )
 
     # 사용자가 인증 되지 않은 케이스

--- a/users/views.py
+++ b/users/views.py
@@ -15,7 +15,7 @@ from django.db import transaction, DatabaseError
 from drf_yasg.utils import swagger_auto_schema
 
 from .serializers import RegisterSerializer
-from swagger import USER_REGISTER_PARAMETERS, LOGIN_PARAMETERS
+from swagger import *
 
 
 # /api/v1/users/register/
@@ -26,8 +26,8 @@ class UserRegisterView(APIView):
         tags=['사용자', '생성', '인증'],
         request_body=USER_REGISTER_PARAMETERS,
         responses={
-            201: '정상적으로 회원가입이 완료되었습니다.',
-            400: '회원가입에 실패했습니다. 입력된 값이 잘못되었습니다. 상세한 내용은 에러 메시지를 확인해주세요.'
+            201: SUCCESS_MESSAGE_201,
+            400: ERROR_MESSAGE_400
         }
     )
     def post(self, request):
@@ -52,9 +52,9 @@ class LoginView(APIView):
         tags=['사용자', '로그인', '인증'],
         request_body=LOGIN_PARAMETERS,
         responses={
-            200: '정상적으로 로그인이 완료되었습니다.',
-            400: '로그인에 실패했습니다. 필수값이 입력되지 않았습니다.',
-            404: '로그인에 실패했습니다. 해당하는 사용자를 찾지 못했습니다.'
+            200: SUCCESS_MESSAGE_200,
+            400: ERROR_MESSAGE_400,
+            404: ERROR_MESSAGE_404
         }
     )
     def post(self, request):
@@ -94,9 +94,8 @@ class LogoutView(APIView):
         operation_description='액세스 토큰을 통해 캐시에 저장된 리프레시 토큰을 블랙리스트에 등록하여 재사용을 막습니다. 액세스 토큰 삭제는 이루어지지 않습니다.',
         tags=['사용자', '로그아웃', '인증'],
         responses={
-            200: '정상적으로 로그아웃이 완료되었습니다.',
-            202: '로그아웃은 성공했습니다. 그러나 정상적으로 로그아웃이 처리되지 않았을 수 있습니다. 에러 메시지를 확인해주세요.',
-            401: '인증되지 않은 사용자는 사용할 수 없습니다.'
+            200: SUCCESS_MESSAGE_200,
+            401: ERROR_MESSAGE_401
         }
     )
     def post(self, request):
@@ -109,7 +108,7 @@ class LogoutView(APIView):
         refresh_token = cache.get(f'{access_token}')
 
         if refresh_token is None:
-            return Response({'data': '로그아웃이 완료되었습니다. 그러나 리프레시 토큰이 정상적으로 처리되지 않았을 수 있습니다.'}, status=status.HTTP_202_ACCEPTED)
+            return Response({'data': '로그아웃이 완료되었습니다. 그러나 리프레시 토큰이 정상적으로 처리되지 않았을 수 있습니다.'}, status=status.HTTP_200_OK)
 
         try:
             # 리프레시 토큰을 문자열에서 리프레시 토큰 객체로 형변환
@@ -123,7 +122,7 @@ class LogoutView(APIView):
             return Response({'data': '로그아웃이 완료되었습니다.'}, status=status.HTTP_200_OK)
         # 리프레시 토큰 처리 중 발생할 수 있는 예외를 처리
         except (InvalidToken, TokenError) as error:
-            return Response({'data': f'{error}'}, status=status.HTTP_202_ACCEPTED)
+            return Response({'data': f'{error}'}, status=status.HTTP_200_OK)
 
 
 # /api/v1/users/invite/
@@ -135,9 +134,9 @@ class UserInviteDetailView(APIView):
         operation_description='사용자에게 온 초대 메시지를 확인합니다.',
         tags=['사용자', '팀', '초대'],
         responses={
-            200: '사용자에게 온 초대 메시지 검색이 성공적으로 완료되었습니다.',
-            204: '사용자에게 온 초대 메시지가 없습니다.',
-            401: '인증되지 않은 사용자는 사용할 수 없습니다.'
+            200: SUCCESS_MESSAGE_200,
+            204: SUCCESS_MESSAGE_204,
+            401: ERROR_MESSAGE_401
         }
     )
     def get(self, request):
@@ -174,10 +173,10 @@ class UserInviteAcceptView(APIView):
         operation_description='사용자에게 온 초대 메시지를 수락합니다.',
         tags=['사용자', '팀', '초대'],
         responses={
-            202: '초대 메시지 수락이 성공적으로 완료되었습니다.',
-            204: '사용자에게 온 초대 메시지가 없습니다.',
-            401: '인증되지 않은 사용자는 사용할 수 없습니다.',
-            500: '요청을 처리하던 중 서버에 문제가 발생했습니다.'
+            200: SUCCESS_MESSAGE_200,
+            204: SUCCESS_MESSAGE_204,
+            401: ERROR_MESSAGE_401,
+            500: ERROR_MESSAGE_500
         }
     )
     def post(self, request):
@@ -226,5 +225,5 @@ class UserInviteAcceptView(APIView):
             )
 
         return Response(
-            {'data': f'{team_name} 팀의 초대를 수락하셨습니다.'}, status=status.HTTP_202_ACCEPTED
+            {'data': f'{team_name} 팀의 초대를 수락하셨습니다.'}, status=status.HTTP_200_OK
         )


### PR DESCRIPTION
## 반영 브랜치

feature/boards/#39 → develop


## 변경 사항

컬럼 순서 수정 기능을 생성했습니다.

인증된 사용자이면서 팀에 소속된 사용자만 기능에 접근할 수 있습니다.

컬럼 id와 순서값을 받아 컬럼의 순서를 변경합니다. 이 때 현재 순서값보다 작은 쪽으로 이동하는지 큰 쪽으로 이동하는지를 구분하고, 현재 순서값과 변경될 순서값 사이 컬럼들의 순서값을 변경한 다음 변경을 시도한 컬럼의 순서값을 변경합니다. 또 해당 과정이 진행되는 동안 에러가 발생하면 변경 사항을 전부 롤백하면서 상태코드 500을 반환합니다.

유효하지 않은 순서값을 입력했을 때 상태코드 400을 반환합니다.

컬럼 id가 잘못 입력되었을 때에는 상태코드 404를 반환합니다.

변경될 순서값이 현재 순서값과 일치한다면 별다른 변경사항 없이 상태코드 200을 반환합니다.

변경을 시도할 순서값이 0 이하이거나 보드 내 전체 컬럼 갯수보다 크다면 상태코드 400을 반환합니다.

여러 상황에 대한 테스트 코드를 작성하고 의도대로 작동하는 것을 확인했습니다.