### PR TITLE
[기능 생성] 티켓 생성 기능 생성

### DIFF
--- a/boards/admin.py
+++ b/boards/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 
-from .models import Board, Column
+from .models import Board, Column, Ticket
 
 
 admin.site.register(Board)
 admin.site.register(Column)
+admin.site.register(Ticket)

--- a/boards/models.py
+++ b/boards/models.py
@@ -45,7 +45,11 @@ class Ticket(models.Model):
         verbose_name='담당자'
     )
     title = models.TextField(verbose_name='제목')
-    tag = models.CharField(max_length=10, choices=TAG_CHOICES)
+    tag = models.CharField(
+        max_length=10,
+        choices=TAG_CHOICES,
+        verbose_name='태그'
+    )
     sequence = models.PositiveIntegerField(verbose_name='순서')
     volume = models.FloatField(verbose_name='작업량')
     ended_at = models.DateField(verbose_name='마감일')

--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Board, Column
+from .models import Board, Column, Ticket
 
 
 class ColumnSerializer(serializers.ModelSerializer):
@@ -9,17 +9,45 @@ class ColumnSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class TicketSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Ticket
+        fields = '__all__'
+
+
 class BoardSerializer(serializers.ModelSerializer):
     # 보드를 그대로 직렬화하면 팀은 팀 id만 나옴
     # 따라서 별도의 메서드를 통해 어떤 값을 반환할지 결정함
     team = serializers.SerializerMethodField()
-    # 보드에 컬럼과 관련된 값은 없지만, 컬럼은 보드를 외래키로 가지고 있음
+    # 보드에 티켓과 관련된 값은 없지만, 티켓은 컬럼을 외래키로, 컬럼은 보드를 외래키로 가지고 있음
     # 이를 활용해 원하는 값을 반환함
     column = serializers.SerializerMethodField()
 
     class Meta:
         model = Board
         fields = ['team', 'column']
+
+        # 해당 데이터에서 필요한 내용만 딕셔너리 형태로 반환
+        # {
+        #    'team': '팀명',
+        #    'data': {
+        #       '컬럼명': {
+        #           'id': 컬럼 id,
+        #           'sequence': 컬럼 순서
+        #           'ticket': {
+        #               '티켓명': {
+        #                   'id': 티켓 id,
+        #                   'charge': 담장자명,
+        #                   'tag': 태그,
+        #                   'sequence': 티켓 순서,
+        #                   'volume': 작업량,
+        #                   'ended_at': 마감일,
+        #               }
+        #           }
+        #       }
+        #        ...
+        #     }
+        # }
 
     # team 필드에 어떤 값을 반환할지 결정하는 메서드
     def get_team(self, obj):
@@ -31,22 +59,42 @@ class BoardSerializer(serializers.ModelSerializer):
         # 시리얼라이저에 들어온 보드 객체에 소속된 모든 컬럼을 오름차순으로 정렬
         columns = Column.objects.filter(board=obj).order_by('sequence')
 
-        # 해당 데이터에서 필요한 내용만 딕셔너리 형태로 반환
-        # {
-        #    'team': '팀명',
-        #    'column': {
-        #       '컬럼명': {
-        #           'id': 컬럼 id,
-        #           'sequence': 컬럼 순서
-        #       }
-        #        ...
-        #     }
-        # }
         column_data = {}
+        ticket_data = {}
         for column in columns:
             column_data[column.title] = {
                 'id': column.id,
                 'sequence': column.sequence
             }
+
+            # 현재 컬럼에 해당하는 모든 티켓을 오름차순으로 정렬
+            tickets = Ticket.objects.filter(column=column).order_by('sequence')
+            for ticket in tickets:
+                # try:
+                ticket_data[ticket.title] = {}
+                # except KeyError:
+                #     print('값없음')
+                #     continue
+
+                try:
+                    ticket_data[ticket.title] = {
+                        'id': ticket.id,
+                        'tag': ticket.tag,
+                        'charge': ticket.charge.username,
+                        'volume': ticket.volume,
+                        'ended_at': ticket.ended_at,
+                        'sequence': ticket.sequence
+                    }
+                except AttributeError:
+                    ticket_data[ticket.title] = {
+                        'id': ticket.id,
+                        'tag': ticket.tag,
+                        'charge': None,
+                        'volume': ticket.volume,
+                        'ended_at': ticket.ended_at,
+                        'sequence': ticket.sequence
+                    }
+
+                column_data[column.title]['ticket'] = ticket_data
 
         return column_data

--- a/boards/tests.py
+++ b/boards/tests.py
@@ -851,6 +851,395 @@ class ColumnDeleteTestCase(APITestCase):
         )
 
 
+# 티켓 생성 테스트
+class TicketCreateTestCase(APITestCase):
+    fixtures = ['db.json']
+
+    def setUp(self):
+        # APIClient 객체 생성
+        self.client = APIClient()
+
+        # /api/v1/boards/ticket/create/
+        self.url = reverse('ticket_create')
+
+    # 정상적인 컬럼 생성 케이스
+    def test_default(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 생성에 필요한 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 1,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_201_CREATED, response.data
+        )
+
+    # 담당자는 입력하지 않지만 정상적인 컬럼 생성 케이스
+    def test_default_no_charge(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 생성에 필요한 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 1
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_201_CREATED, response.data
+        )
+
+    # 제목을 입력하지 않고 생성을 시도하는 케이스
+    def test_no_title(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 제목이 없는 데이터 생성
+        request_data = {
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 1,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 태그를 입력하지 않고 생성을 시도하는 케이스
+    def test_no_tag(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 태그가 없는 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 1,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 업무량을 입력하지 않고 생성을 시도하는 케이스
+    def test_no_volume(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 업무량이 없는 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'ended_at': '2023-11-19',
+            'column': 1,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 마감일을 입력하지 않고 생성을 시도하는 케이스
+    def test_no_ended_at(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 마감일이 없는 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'column': 1,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 컬럼 id를 입력하지 않고 생성을 시도하는 케이스
+    def test_no_column(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 id가 없는 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 유효하지 않은 컬럼 id를 입력해 생성을 시도하는 케이스
+    def test_invalid_column(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 id가 유효하지 않은 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 'INVALID',
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 없는 컬럼 id를 입력해 생성을 시도하는 케이스
+    def test_column_id(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 컬럼 id가 유효하지 않은 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 5,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 유효하지 않은 담당자를 입력해 생성을 시도하는 케이스
+    def test_invalid_charge(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 담당자 유효하지 않은 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 1,
+            'charge': 'INVALID'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 팀에 소속되지 않은 사용자가 컬럼 생성을 시도하는 케이스
+    def test_not_teammate(self):
+        # 기존 DB의 사용자 중 팀이 없는 사용자로 로그인 시도
+        login_data = {
+            'username': 'normaluser4',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 티켓 생성에 필요한 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 1,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        # 권한 문제이기 때문에 상태코드는 403이 나옴
+        self.assertEqual(
+            response.status_code, status.HTTP_403_FORBIDDEN, response.data
+        )
+
+    # 로그인하지 않은 사용자가 티켓 생성을 시도하는 케이스
+    def test_not_authorized(self):
+        # 티켓 생성에 필요한 데이터 생성
+        request_data = {
+            'title': '테스트',
+            'tag': 'BE',
+            'volume': 4.0,
+            'ended_at': '2023-11-19',
+            'column': 1,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.post(self.url, request_data)
+
+        # 인증 문제이기 때문에 상태코드는 401이 나옴
+        self.assertEqual(
+            response.status_code, status.HTTP_401_UNAUTHORIZED, response.data
+        )
+
+
 # 보드 목록 테스트
 class BoardListTestCase(APITestCase):
     fixtures = ['db.json']

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -5,7 +5,8 @@ from .views import (
     ColumnCreateView,
     ColumnUpdateView,
     ColumnUpdateSequenceView,
-    ColumnDeleteView
+    ColumnDeleteView,
+    TicketCreateView
 )
 
 
@@ -18,5 +19,6 @@ urlpatterns = [
         ColumnUpdateSequenceView.as_view(),
         name='column_sequence_update'
     ),
-    path('column/delete/', ColumnDeleteView.as_view(), name='column_delete')
+    path('column/delete/', ColumnDeleteView.as_view(), name='column_delete'),
+    path('ticket/create/', TicketCreateView.as_view(), name='ticket_create'),
 ]

--- a/db.json
+++ b/db.json
@@ -853,6 +853,50 @@
         }
     },
     {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 31,
+        "fields": {
+            "user": 1,
+            "jti": "12b84a1a1e3b4de69adcc17f4e97b30e",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTU2NzUyNiwiaWF0IjoxNzAwMzU3OTI2LCJqdGkiOiIxMmI4NGExYTFlM2I0ZGU2OWFkY2MxN2Y0ZTk3YjMwZSIsInVzZXJfaWQiOjF9.Sn-JqdQZPZ7je_jxwIwsLcyX23Mob4sJBkGBiVHSg7I",
+            "created_at": "2023-11-19T01:38:46.067Z",
+            "expires_at": "2023-12-03T01:38:46Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 32,
+        "fields": {
+            "user": 1,
+            "jti": "87d09a6c42154d0caeba1dd8ccb04507",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTU3MDg5MCwiaWF0IjoxNzAwMzYxMjkwLCJqdGkiOiI4N2QwOWE2YzQyMTU0ZDBjYWViYTFkZDhjY2IwNDUwNyIsInVzZXJfaWQiOjF9.qm8f098OMJD64Ik1YzPKa2ReXljgCxHpfkrhMFtAW2g",
+            "created_at": "2023-11-19T02:34:50.222Z",
+            "expires_at": "2023-12-03T02:34:50Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 33,
+        "fields": {
+            "user": 1,
+            "jti": "d0cf1903c9794091932a9f1e4d479c54",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTU3MTg1OCwiaWF0IjoxNzAwMzYyMjU4LCJqdGkiOiJkMGNmMTkwM2M5Nzk0MDkxOTMyYTlmMWU0ZDQ3OWM1NCIsInVzZXJfaWQiOjF9.SdC34IaGjGfBORTN6KcnP0tOlb5JgSc1fvVoY3Vt30s",
+            "created_at": "2023-11-19T02:50:58.304Z",
+            "expires_at": "2023-12-03T02:50:58Z"
+        }
+    },
+    {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 34,
+        "fields": {
+            "user": 1,
+            "jti": "c955e056a69d4737889deeaf3b7bc3d2",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTU3MjA2OCwiaWF0IjoxNzAwMzYyNDY4LCJqdGkiOiJjOTU1ZTA1NmE2OWQ0NzM3ODg5ZGVlYWYzYjdiYzNkMiIsInVzZXJfaWQiOjF9.sCn8GeQomAvO9gCjvGUeZYPgzgvXCKRDcN2j08DScwY",
+            "created_at": "2023-11-19T02:54:28.713Z",
+            "expires_at": "2023-12-03T02:54:28Z"
+        }
+    },
+    {
         "model": "token_blacklist.blacklistedtoken",
         "pk": 1,
         "fields": { "token": 1, "blacklisted_at": "2023-11-18T10:42:48.250Z" }
@@ -976,6 +1020,11 @@
         "model": "token_blacklist.blacklistedtoken",
         "pk": 25,
         "fields": { "token": 27, "blacklisted_at": "2023-11-18T12:43:24.654Z" }
+    },
+    {
+        "model": "token_blacklist.blacklistedtoken",
+        "pk": 26,
+        "fields": { "token": 34, "blacklisted_at": "2023-11-19T02:58:48.970Z" }
     },
     {
         "model": "users.user",
@@ -1222,5 +1271,31 @@
         "model": "boards.column",
         "pk": 6,
         "fields": { "board": 2, "title": "Review", "sequence": 3 }
+    },
+    {
+        "model": "boards.ticket",
+        "pk": 1,
+        "fields": {
+            "column": 1,
+            "charge": null,
+            "title": "첫번째티켓",
+            "tag": "FE",
+            "sequence": 1,
+            "volume": 8.0,
+            "ended_at": "2023-11-30"
+        }
+    },
+    {
+        "model": "boards.ticket",
+        "pk": 2,
+        "fields": {
+            "column": 1,
+            "charge": 6,
+            "title": "두번째",
+            "tag": "BE",
+            "sequence": 2,
+            "volume": 4.5,
+            "ended_at": "2023-12-01"
+        }
     }
 ]

--- a/swagger.py
+++ b/swagger.py
@@ -16,7 +16,8 @@ USER_REGISTER_PARAMETERS = openapi.Schema(
     properties={
         'username': openapi.Schema(type=openapi.TYPE_STRING, description='계정명'),
         'password': openapi.Schema(type=openapi.TYPE_STRING, description='비밀번호')
-    }
+    },
+    required=['username', 'password']
 )
 
 LOGIN_PARAMETERS = openapi.Schema(
@@ -24,30 +25,32 @@ LOGIN_PARAMETERS = openapi.Schema(
     properties={
         'username': openapi.Schema(type=openapi.TYPE_STRING, description='계정명'),
         'password': openapi.Schema(type=openapi.TYPE_STRING, description='비밀번호')
-    }
+    },
+    required=['username', 'password']
 )
 
 TEAM_CREATE_PARAMETERS = openapi.Schema(
     type=openapi.TYPE_OBJECT,
     properties={
         'name': openapi.Schema(type=openapi.TYPE_STRING, description='팀명')
-    }
+    },
+    required=['name']
 )
 
 TEAM_INVITE_PARAMETERS = openapi.Schema(
     type=openapi.TYPE_OBJECT,
     properties={
-        'target': openapi.Schema(type=openapi.TYPE_STRING, description='초대할 사용자명'),
-        'team': openapi.Schema(type=openapi.TYPE_STRING, description='초대하는 팀명')
-    }
+        'target': openapi.Schema(type=openapi.TYPE_STRING, description='초대할 사용자명')
+    },
+    required=['target']
 )
 
 COLUMN_CREATE_PARAMETER = openapi.Schema(
     type=openapi.TYPE_OBJECT,
     properties={
-        'team': openapi.Schema(type=openapi.TYPE_STRING, description='팀명'),
         'title': openapi.Schema(type=openapi.TYPE_STRING, description='컬럼 제목')
-    }
+    },
+    required=['title']
 )
 
 COLUMN_UPDATE_PARAMETER = openapi.Schema(
@@ -55,7 +58,8 @@ COLUMN_UPDATE_PARAMETER = openapi.Schema(
     properties={
         'column': openapi.Schema(type=openapi.TYPE_INTEGER, description='컬럼 id'),
         'title': openapi.Schema(type=openapi.TYPE_STRING, description='컬럼 제목')
-    }
+    },
+    required=['column']
 )
 
 COLUMN_UPDATE_SEQUENCE_PARAMETER = openapi.Schema(
@@ -63,12 +67,27 @@ COLUMN_UPDATE_SEQUENCE_PARAMETER = openapi.Schema(
     properties={
         'column': openapi.Schema(type=openapi.TYPE_INTEGER, description='컬럼 id'),
         'sequence': openapi.Schema(type=openapi.TYPE_STRING, description='컬럼 순서')
-    }
+    },
+    required=['column', 'sequence']
 )
 
 COLUMN_DELETE_PARAMETER = openapi.Schema(
     type=openapi.TYPE_OBJECT,
     properties={
         'column': openapi.Schema(type=openapi.TYPE_INTEGER, description='컬럼 id')
-    }
+    },
+    required=['column']
+)
+
+TICKET_CREATE_PARAMETER = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'column': openapi.Schema(type=openapi.TYPE_INTEGER, description='컬럼 id'),
+        'charge': openapi.Schema(type=openapi.TYPE_STRING, description='담당자 계정명'),
+        'title': openapi.Schema(type=openapi.TYPE_STRING, description='티켓 제목'),
+        'tag': openapi.Schema(type=openapi.TYPE_STRING, description='태그'),
+        'volume': openapi.Schema(type=openapi.TYPE_NUMBER, description='작업량'),
+        'ended_at': openapi.Schema(type=openapi.TYPE_STRING, description='마감일')
+    },
+    required=['column', 'title', 'tag', 'volume', 'ended_at']
 )


### PR DESCRIPTION
## 반영 브랜치

feature/boards/#42 → develop


## 변경 사항

티켓 생성 기능을 생성했습니다.

팀에 소속된 사용자가 티켓 제목, 태그, 작업량, 업무량, 마감일, 컬럼 id, 담당자 계정명을 입력하면 신규 티켓을 생성합니다. 이 때 담당자 계정명은 필수값이 아니며, 입력하지 않을 경우 Null 값이 들어갑니다.

순서의 경우, 티켓이 소속될 컬럼 내부의 모든 티켓의 순서를 내림차순으로 정렬하여 가장 마지막 번호를 부여합니다.

태그의 경우, 모델에서 사전에 지정된 태그만 받도록 설정했습니다. 아예 벗어나는 경우 상태코드 400을 반환하지만, 태그의 코드 네임이나 정식 명칭을 입력하게 되면 코드 네임 쪽으로 정리해 DB에 저장하도록 만들었습니다.

기타 입력된 값이 잘못된 경우에는 상태코드 400을, 모델 객체를 찾을 수 없는 경우에는 상태코드 404를, 인증되지 않은 사용자는 상태코드 401, 권한이 없는 사용자는 상태코드 403을 반환합니다.

보드의 시리얼라이저를 수정해 보드 목록 API를 호출하면 보드 내의 컬럼, 컬럼 내의 티켓까지 전부 반환하도록 만들었습니다.

다양한 상황에 대한 테스트 코드를 작성하고 의도대로 작동하는 것을 확인했습니다.
