### PR TITLE
[기능 추가] 티켓 수정 기능 생성

### DIFF
--- a/boards/tests.py
+++ b/boards/tests.py
@@ -1448,6 +1448,38 @@ class TicketUpdateTestCase(APITestCase):
             response.status_code, status.HTTP_200_OK, response.data
         )
 
+    # 유효하지 않은 태그로 수정을 시도하는 케이스
+    def test_invalid_tag(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 유효하지 않은 태그값
+        request_data = {
+            'ticket': 1,
+            'title': 'update',
+            'tag': 'INVALID',
+            'volume': 4,
+            'ended_at': '2023-11-20'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
     # 수정할 데이터 없이 수정을 시도하는 케이스
     def test_no_data(self):
         # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도

--- a/boards/tests.py
+++ b/boards/tests.py
@@ -295,7 +295,7 @@ class ColumnUpdateTestCase(APITestCase):
         )
 
     # 컬럼 순서 변경을 시도하는 케이스
-    def test_column_out_of_range(self):
+    def test_sequence_update(self):
         # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
         login_data = {
             'username': 'teamleader1',
@@ -355,7 +355,7 @@ class ColumnUpdateTestCase(APITestCase):
         )
 
     # 인증되지 않은 사용자가 변경을 시도하는 케이스
-    def test_not_teammate(self):
+    def test_not_authorized(self):
         # 정상적인 데이터
         request_data = {
             'column': 1,
@@ -1235,6 +1235,328 @@ class TicketCreateTestCase(APITestCase):
         response = self.client.post(self.url, request_data)
 
         # 인증 문제이기 때문에 상태코드는 401이 나옴
+        self.assertEqual(
+            response.status_code, status.HTTP_401_UNAUTHORIZED, response.data
+        )
+
+
+# 티켓 수정 테스트
+class TicketUpdateTestCase(APITestCase):
+    fixtures = ['db.json']
+
+    def setUp(self):
+        # APIClient 객체 생성
+        self.client = APIClient()
+
+        # /api/v1/boards/ticket/update/
+        self.url = reverse('ticket_update')
+
+    # 정상적인 티켓 수정 케이스
+    def test_default(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 티켓 수정에 필요한 데이터 생성
+        request_data = {
+            'ticket': 1,
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': '2023-11-20',
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, response.data
+        )
+
+    # 팀원이 시도하는 정상적인 티켓 수정 케이스
+    def test_default_teammate(self):
+        # 기존 DB의 사용자 중 팀원 사용자로 로그인 시도
+        login_data = {
+            'username': 'normaluser1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 티켓 수정에 필요한 데이터 생성
+        request_data = {
+            'ticket': 1,
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': '2023-11-20',
+            'charge': 'teamleader1'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, response.data
+        )
+
+    # 티켓 id 없이 수정을 시도하는 케이스
+    def test_no_ticket_id(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 티켓 id 없음
+        request_data = {
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': '2023-11-20',
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 잘못된 티켓 id로 수정을 시도하는 케이스
+    def test_invalid_ticket_id(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 유효하지 않은 티켓 id
+        request_data = {
+            'ticket': 'INVALID',
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': '2023-11-20',
+            'charge': 'teamleader1'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 없는 티켓 id로 수정을 시도하는 케이스
+    def test_ticket_id_over(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 유효하지 않은 티켓 id
+        request_data = {
+            'ticket': 3,
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': '2023-11-20',
+            'charge': 'teamleader1'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 담당자 데이터 없이 수정을 시도하는 케이스
+    def test_no_charge(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 담당자 데이터 없음
+        request_data = {
+            'ticket': 1,
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': '2023-11-20'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        # 정상적으로 값이 수정되어야 함
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, response.data
+        )
+
+    # 수정할 데이터 없이 수정을 시도하는 케이스
+    def test_no_data(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 데이터 없음
+        request_data = {}
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_404_NOT_FOUND, response.data
+        )
+
+    # 티켓 순서 변경을 시도하는 케이스
+    def test_sequence_update(self):
+        # 기존 DB의 사용자 중 팀장 사용자로 로그인 시도
+        login_data = {
+            'username': 'teamleader1',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 티켓 순서를 입력함
+        request_data = {
+            'ticket': 1,
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': 2023-11-20,
+            'charge': 'normaluser1',
+            'sequence': 10
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+
+    # 팀에 소속되지 않은 사용자가 변경을 시도하는 케이스
+    def test_not_teammate(self):
+        # 기존 DB의 사용자 중 팀에 소속되지 않은 사용자로 로그인
+        login_data = {
+            'username': 'normaluser4',
+            'password': 'qwerty123!@#'
+        }
+
+        # 해당 데이터로 로그인 후 액세스 토큰 획득
+        access_token = self.client.post(
+            reverse('login'),
+            login_data
+        ).data.get('access')
+
+        # APIClient 객체에 인증 진행
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+        # 정상적인 데이터
+        request_data = {
+            'ticket': 1,
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': 2023-11-20,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        # 팀 구성원 전체에 권한이 부여되므로, 팀에 소속되지 않으면 사용 불가
+        self.assertEqual(
+            response.status_code, status.HTTP_403_FORBIDDEN, response.data
+        )
+
+    # 인증되지 않은 사용자가 변경을 시도하는 케이스
+    def test_not_authorized(self):
+        # 정상적인 데이터
+        request_data = {
+            'ticket': 1,
+            'title': 'update',
+            'tag': 'Doc',
+            'volume': 4,
+            'ended_at': 2023-11-20,
+            'charge': 'normaluser1'
+        }
+
+        response = self.client.put(self.url, request_data)
+
+        # 인증된 사용자에게 권한을 부여하므로, 인증되지 않으면 사용 불가
         self.assertEqual(
             response.status_code, status.HTTP_401_UNAUTHORIZED, response.data
         )

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -6,7 +6,8 @@ from .views import (
     ColumnUpdateView,
     ColumnUpdateSequenceView,
     ColumnDeleteView,
-    TicketCreateView
+    TicketCreateView,
+    TicketUpdateView,
 )
 
 
@@ -21,4 +22,5 @@ urlpatterns = [
     ),
     path('column/delete/', ColumnDeleteView.as_view(), name='column_delete'),
     path('ticket/create/', TicketCreateView.as_view(), name='ticket_create'),
+    path('ticket/update/', TicketUpdateView.as_view(), name='ticket_update'),
 ]

--- a/boards/views.py
+++ b/boards/views.py
@@ -438,7 +438,7 @@ class TicketUpdateView(APIView):
         operation_id='티켓 수정',
         operation_description='티켓 id와 기타 데이터를 받아 티켓을 수정합니다.',
         tags=['티켓', '수정'],
-        request_body=COLUMN_UPDATE_PARAMETER,
+        request_body=TICKET_UPDATE_PARAMETER,
         responses={
             200: SUCCESS_MESSAGE_200,
             400: ERROR_MESSAGE_400,

--- a/db.json
+++ b/db.json
@@ -897,6 +897,17 @@
         }
     },
     {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 35,
+        "fields": {
+            "user": 1,
+            "jti": "142089b8f06a4960bc06f20457f8990d",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTU3NTAxNywiaWF0IjoxNzAwMzY1NDE3LCJqdGkiOiIxNDIwODliOGYwNmE0OTYwYmMwNmYyMDQ1N2Y4OTkwZCIsInVzZXJfaWQiOjF9.dk66uKzUTsc0Hg3tOMDrSiLp7I-gkyY1fOohNj0Jyrw",
+            "created_at": "2023-11-19T03:43:37.912Z",
+            "expires_at": "2023-12-03T03:43:37Z"
+        }
+    },
+    {
         "model": "token_blacklist.blacklistedtoken",
         "pk": 1,
         "fields": { "token": 1, "blacklisted_at": "2023-11-18T10:42:48.250Z" }
@@ -1291,7 +1302,7 @@
         "fields": {
             "column": 1,
             "charge": 6,
-            "title": "두번째",
+            "title": "두번째 티켓",
             "tag": "BE",
             "sequence": 2,
             "volume": 4.5,

--- a/swagger.py
+++ b/swagger.py
@@ -91,3 +91,16 @@ TICKET_CREATE_PARAMETER = openapi.Schema(
     },
     required=['column', 'title', 'tag', 'volume', 'ended_at']
 )
+
+TICKET_UPDATE_PARAMETER = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'column': openapi.Schema(type=openapi.TYPE_INTEGER, description='컬럼 id'),
+        'charge': openapi.Schema(type=openapi.TYPE_STRING, description='담당자 계정명'),
+        'title': openapi.Schema(type=openapi.TYPE_STRING, description='티켓 제목'),
+        'tag': openapi.Schema(type=openapi.TYPE_STRING, description='태그'),
+        'volume': openapi.Schema(type=openapi.TYPE_NUMBER, description='작업량'),
+        'ended_at': openapi.Schema(type=openapi.TYPE_STRING, description='마감일')
+    },
+    required=['column']
+)

--- a/swagger.py
+++ b/swagger.py
@@ -95,7 +95,7 @@ TICKET_CREATE_PARAMETER = openapi.Schema(
 TICKET_UPDATE_PARAMETER = openapi.Schema(
     type=openapi.TYPE_OBJECT,
     properties={
-        'column': openapi.Schema(type=openapi.TYPE_INTEGER, description='컬럼 id'),
+        'ticket': openapi.Schema(type=openapi.TYPE_INTEGER, description='티켓 id'),
         'charge': openapi.Schema(type=openapi.TYPE_STRING, description='담당자 계정명'),
         'title': openapi.Schema(type=openapi.TYPE_STRING, description='티켓 제목'),
         'tag': openapi.Schema(type=openapi.TYPE_STRING, description='태그'),


### PR DESCRIPTION
## 반영 브랜치

feature/boards/#44 → develop


## 변경 사항

티켓 수정 기능을 생성했습니다.

티켓 id, 담당자, 티켓 제목, 태그, 작업량, 마감일을 입력받아 티켓을 수정하는데, 이 때 티켓 id를 제외하고는 필수값이 없습니다.

티켓 순서 변경은 시도할 수 없습니다. 순서값이 들어오면 상태코드 400을 반환합니다.

수정할 데이터 중 담당자나 마감일의 경우 별도의 객체를 찾거나 형식을 변경해야 합니다. 그러나 request.data는 불변 객체를 반환하므로, 이를 별도의 변수에 깊은 복사하여 사용합니다. 담당자는 사용자 객체에서 해당 인원을 찾고 같은 팀원이 맞는지 확인한 다음 입력되고, 마감일은 YYYY-MM-DD 형식으로 입력됩니다.

값이 입력된 필드만 업데이트됩니다.

다양한 케이스에 대한 테스트 코드를 작성하고 의도대로 작동하는 것을 확인했습니다.