### PR TITLE
[기능 생성] 티켓 삭제 기능 생성

### DIFF
--- a/boards/urls.py
+++ b/boards/urls.py
@@ -9,6 +9,7 @@ from .views import (
     TicketCreateView,
     TicketUpdateView,
     TicketUpdateSequenceView,
+    TicketDeleteView
 )
 
 
@@ -29,4 +30,5 @@ urlpatterns = [
         TicketUpdateSequenceView.as_view(),
         name='ticket_sequence_update'
     ),
+    path('ticket/delete/', TicketDeleteView.as_view(), name='ticket_delete')
 ]

--- a/db.json
+++ b/db.json
@@ -919,6 +919,17 @@
         }
     },
     {
+        "model": "token_blacklist.outstandingtoken",
+        "pk": 37,
+        "fields": {
+            "user": 1,
+            "jti": "cf067db62f6541fe85b59fbe74dde9e0",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwMTU5MDQ5NywiaWF0IjoxNzAwMzgwODk3LCJqdGkiOiJjZjA2N2RiNjJmNjU0MWZlODViNTlmYmU3NGRkZTllMCIsInVzZXJfaWQiOjF9.pn1Rj3lDYqAfj2Ez2bbweqNEvOHpLJNMt0etmS-u6dY",
+            "created_at": "2023-11-19T08:01:37.449Z",
+            "expires_at": "2023-12-03T08:01:37Z"
+        }
+    },
+    {
         "model": "token_blacklist.blacklistedtoken",
         "pk": 1,
         "fields": { "token": 1, "blacklisted_at": "2023-11-18T10:42:48.250Z" }
@@ -1323,6 +1334,19 @@
             "sequence": 2,
             "volume": 4.5,
             "ended_at": "2023-12-01"
+        }
+    },
+    {
+        "model": "boards.ticket",
+        "pk": 3,
+        "fields": {
+            "column": 2,
+            "charge": null,
+            "title": "세번째티켓",
+            "tag": "D",
+            "sequence": 1,
+            "volume": 1.0,
+            "ended_at": "2023-12-02"
         }
     }
 ]

--- a/swagger.py
+++ b/swagger.py
@@ -114,3 +114,11 @@ TICKET_UPDATE_SEQUENCE_PARAMETER = openapi.Schema(
     },
     required=['ticket', 'column_sequence', 'ticket_sequence']
 )
+
+TICKET_DELETE_PARAMETER = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'ticket': openapi.Schema(type=openapi.TYPE_INTEGER, description='티켓 id')
+    },
+    required=['ticket']
+)


### PR DESCRIPTION
## 반영 브랜치

feature/boards/#45 → develop


## 변경 사항

티켓 삭제 기능을 생성했습니다.

사용자가 티켓 id를 입력하면 소유한 보드를 확인해 해당 티켓을 삭제하고 남은 티켓들은 모두 다시 순서를 매깁니다. 해당 과정들을 하나의 트랜잭션으로 묶어 이상이 발생할 경우 롤백합니다.

권한은 팀의 팀원과 팀장에게만 부여됩니다. 

다양한 케이스에 대한 테스트 코드를 작성하고 의도대로 작동하는 것을 확인했습니다.